### PR TITLE
Add DVI_Mode config switch

### DIFF
--- a/sys/hdmi_config.sv
+++ b/sys/hdmi_config.sv
@@ -18,6 +18,7 @@ module hdmi_config
 	input       iAR,
 	
 	input       audio_48k,
+        input       dvi,
 
 	//	I2C Side
 	output		I2C_SCL,
@@ -193,7 +194,7 @@ wire [15:0] init_data[58] =
 	16'hAA00,					// ADI required Write.
 	16'hAB40,					// ADI required Write.
 	
-	{8'hAF, 8'b0001_0110},	// [7]=0 HDCP Disabled.
+	{8'hAF,  6'b0001_01,~dvi,1'b0},	// [7]=0 HDCP Disabled.
 									// [6:5] must be b00!
 									// [4]=1 Current frame IS HDCP encrypted!??? (HDCP disabled anyway?)
 									// [3:2] must be b01!

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -173,6 +173,7 @@ cyclonev_hps_interface_mpu_general_purpose h2f_gp
 reg [15:0] cfg;
 
 reg  cfg_ready = 0;
+wire dvi       = cfg[7];
 wire audio_96k = cfg[6];
 wire ypbpr_en  = cfg[5];
 wire csync     = cfg[3];
@@ -463,6 +464,8 @@ hdmi_config hdmi_config
 	.iRST_N(cfg_ready),
 	.I2C_SCL(HDMI_I2C_SCL),
 	.I2C_SDA(HDMI_I2C_SDA),
+
+        .dvi(dvi),
 
 	.audio_48k(~audio_96k),
 	.iRES(4), // 720p


### PR DESCRIPTION
Example implementation. Needed for all cores using the MiSTer framework to support the dvi_mode config switch.