### PR TITLE
WIP: Improve C1541 realism

### DIFF
--- a/c64.sv
+++ b/c64.sv
@@ -202,8 +202,8 @@ assign VGA_SCALER = 0;
 localparam CONF_STR = {
 	"C64;UART2400;",
 	"h0-;",
-	"S0,D64T64,Mount Drive #8;",
-	"H0S1,D64T64,Mount Drive #9;",
+	"S0,I64T64,Mount Drive #8;",
+	"H0S1,I64T64,Mount Drive #9;",
 	"-;",
 	"F4,PRG,Load File;",
 	"F5,CRT,Load Cartridge;",

--- a/files.qip
+++ b/files.qip
@@ -18,4 +18,5 @@ set_global_assignment -name VHDL_FILE rtl/fpga64_keyboard.vhd
 set_global_assignment -name VHDL_FILE rtl/fpga64_bustiming.vhd
 set_global_assignment -name VHDL_FILE rtl/fpga64_buslogic.vhd
 set_global_assignment -name VHDL_FILE rtl/fpga64_sid_iec.vhd
+set_global_assignment -name VERILOG_FILE rtl/lfsr.v
 set_global_assignment -name SYSTEMVERILOG_FILE c64.sv

--- a/rtl/c1541/bram.vhd
+++ b/rtl/c1541/bram.vhd
@@ -1,0 +1,93 @@
+--------------------------------------------------------------
+-- Dual port Block RAM different parameters and clocks on ports
+--------------------------------------------------------------
+LIBRARY ieee;
+USE ieee.std_logic_1164.all;
+
+LIBRARY altera_mf;
+USE altera_mf.altera_mf_components.all;
+
+entity dpram_difclk is
+	generic (
+		addr_width_a  : integer := 8;
+		data_width_a  : integer := 8;
+		addr_width_b  : integer := 8;
+		data_width_b  : integer := 8;
+		mem_init_file : string := " "
+	);
+	PORT
+	(
+		clock0		: in  STD_LOGIC;
+		clock1		: in  STD_LOGIC;
+		
+		address_a	: in  STD_LOGIC_VECTOR (addr_width_a-1 DOWNTO 0);
+		data_a		: in  STD_LOGIC_VECTOR (data_width_a-1 DOWNTO 0) := (others => '0');
+		enable_a		: in  STD_LOGIC := '1';
+		wren_a		: in  STD_LOGIC := '0';
+		q_a			: out STD_LOGIC_VECTOR (data_width_a-1 DOWNTO 0);
+		cs_a        : in  std_logic := '1';
+
+		address_b	: in  STD_LOGIC_VECTOR (addr_width_b-1 DOWNTO 0) := (others => '0');
+		data_b		: in  STD_LOGIC_VECTOR (data_width_b-1 DOWNTO 0) := (others => '0');
+		enable_b		: in  STD_LOGIC := '1';
+		wren_b		: in  STD_LOGIC := '0';
+		q_b			: out STD_LOGIC_VECTOR (data_width_b-1 DOWNTO 0);
+		cs_b        : in  std_logic := '1'
+	);
+end entity;
+
+
+ARCHITECTURE SYN OF dpram_difclk IS
+
+	signal q0 : std_logic_vector((data_width_a - 1) downto 0);
+	signal q1 : std_logic_vector((data_width_b - 1) downto 0);
+
+BEGIN
+	q_a<= q0 when cs_a = '1' else (others => '1');
+	q_b<= q1 when cs_b = '1' else (others => '1');
+
+	altsyncram_component : altsyncram
+	GENERIC MAP (
+		address_reg_b => "CLOCK1",
+		clock_enable_input_a => "NORMAL",
+		clock_enable_input_b => "NORMAL",
+		clock_enable_output_a => "BYPASS",
+		clock_enable_output_b => "BYPASS",
+		indata_reg_b => "CLOCK1",
+		intended_device_family => "Cyclone V",
+		lpm_type => "altsyncram",
+		numwords_a => 2**addr_width_a,
+		numwords_b => 2**addr_width_b,
+		operation_mode => "BIDIR_DUAL_PORT",
+		outdata_aclr_a => "NONE",
+		outdata_aclr_b => "NONE",
+		outdata_reg_a => "UNREGISTERED",
+		outdata_reg_b => "UNREGISTERED",
+		power_up_uninitialized => "FALSE",
+		read_during_write_mode_port_a => "NEW_DATA_NO_NBE_READ",
+		read_during_write_mode_port_b => "NEW_DATA_NO_NBE_READ",
+		init_file => mem_init_file, 
+		widthad_a => addr_width_a,
+		widthad_b => addr_width_b,
+		width_a => data_width_a,
+		width_b => data_width_b,
+		width_byteena_a => 1,
+		width_byteena_b => 1,
+		wrcontrol_wraddress_reg_b => "CLOCK1"
+	)
+	PORT MAP (
+		address_a => address_a,
+		address_b => address_b,
+		clock0 => clock0,
+		clock1 => clock1,
+		clocken0 => enable_a,
+		clocken1 => enable_b,
+		data_a => data_a,
+		data_b => data_b,
+		wren_a => wren_a and cs_a,
+		wren_b => wren_b and cs_b,
+		q_a => q0,
+		q_b => q1
+	);
+
+END SYN;

--- a/rtl/c1541/c1541.qip
+++ b/rtl/c1541/c1541.qip
@@ -4,3 +4,4 @@ set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) c
 set_global_assignment -name VERILOG_FILE [file join $::quartus(qip_path) c1541_logic.v ]
 set_global_assignment -name VERILOG_FILE [file join $::quartus(qip_path) c1541_sd.v ]
 set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) c1541.vhd ]
+set_global_assignment -name VHDL_FILE [file join $::quartus(qip_path) bram.vhd ]

--- a/rtl/c1541/c1541_gcr.sv
+++ b/rtl/c1541/c1541_gcr.sv
@@ -21,7 +21,7 @@ module c1541_gcr
 	output reg [7:0] dout,    // data from ram to 1541 logic
 	input      [7:0] din,     // data from 1541 logic to ram
 	input            mode,    // read/write
-	input            mtr,     // stepper motor on/off
+	input            mtr,     // spindle motor on/off
 	input      [1:0] freq,    // motor (gcr_bit) frequency
 	output           sync_n,  // reading SYNC bytes
 	output reg       byte_n,  // byte ready

--- a/rtl/c1541/c1541_logic.v
+++ b/rtl/c1541/c1541_logic.v
@@ -30,9 +30,9 @@ module c1541_logic
 	input  [1:0] ds,			// device select
 	input  [7:0] din,			// disk read data
 	output [7:0] dout,		// disk write data
-	output       mode,		// read/write
+	output       mode,		// 1=read, 0=write
 	output [1:0] stp,			// stepper motor control
-	output       mtr,			// stepper motor on/off
+	output       mtr,			// spindle motor on/off
 	output [1:0] freq,		// motor frequency
 	input        sync_n,		// reading SYNC bytes
 	input        byte_n,		// byte ready
@@ -47,8 +47,7 @@ assign sb_clk_out  = ~(uc1_pb_o[3] | ~uc1_pb_oe[3]);
 assign dout = uc3_pa_o  | ~uc3_pa_oe;
 assign mode = uc3_cb2_o | ~uc3_cb2_oe;
 
-assign stp[1] = uc3_pb_o[0]   | ~uc3_pb_oe[0];
-assign stp[0] = uc3_pb_o[1]   | ~uc3_pb_oe[1];
+assign stp    = uc3_pb_o[1:0] | ~uc3_pb_oe[1:0];
 assign mtr    = uc3_pb_o[2]   | ~uc3_pb_oe[2];
 assign act    = uc3_pb_o[3]   | ~uc3_pb_oe[3];
 assign freq   = uc3_pb_o[6:5] | ~uc3_pb_oe[6:5];

--- a/rtl/c1541/c1541_logic.v
+++ b/rtl/c1541/c1541_logic.v
@@ -33,7 +33,8 @@ module c1541_logic
 	output       mode,		// 1=read, 0=write
 	output [1:0] stp,			// stepper motor control
 	output       mtr,			// spindle motor on/off
-	output [1:0] freq,		// motor frequency
+	output       soe,		// serial output enable
+	output [1:0] freq,		// bit clock adjustment for track density
 	input        sync_n,		// reading SYNC bytes
 	input        byte_n,		// byte ready
 	input        wps_n,		// write-protect sense
@@ -46,6 +47,7 @@ assign sb_clk_out  = ~(uc1_pb_o[3] | ~uc1_pb_oe[3]);
 
 assign dout = uc3_pa_o  | ~uc3_pa_oe;
 assign mode = uc3_cb2_o | ~uc3_cb2_oe;
+assign soe  = uc3_ca2_o | ~uc3_ca2_oe;
 
 assign stp    = uc3_pb_o[1:0] | ~uc3_pb_oe[1:0];
 assign mtr    = uc3_pb_o[2]   | ~uc3_pb_oe[2];
@@ -105,7 +107,7 @@ wire [23:0] cpu_a;
 wire  [7:0] cpu_do;
 wire        cpu_rw;
 wire        cpu_irq_n = ~(uc1_irq | uc3_irq);
-wire        cpu_so_n = byte_n | ~soe;
+wire        cpu_so_n = byte_n | ~soe; // XXX: ~soe unneeded ?
 
 T65 cpu
 (
@@ -187,7 +189,6 @@ wire       uc3_cb2_oe;
 wire [7:0] uc3_pa_oe;
 wire [7:0] uc3_pb_o;
 wire [7:0] uc3_pb_oe;
-wire       soe = uc3_ca2_o | ~uc3_ca2_oe;
 
 c1541_via6522 uc3
 (

--- a/rtl/c1541/c1541_sd.v
+++ b/rtl/c1541/c1541_sd.v
@@ -174,7 +174,6 @@ c1541_track c1541_track
 	.disk_change(disk_change),
 	.stp(stp),
 	.mtr(mtr),
-	.act(act),
 	.tr00_sense_n(tr00_sense_n),
 
 	.clk(clk_c1541),

--- a/rtl/c1541/c1541_sd.v
+++ b/rtl/c1541/c1541_sd.v
@@ -88,7 +88,10 @@ wire       mode; // read/write
 wire [1:0] stp;
 wire       mtr;
 wire       act;
+wire       soe;
 wire [1:0] freq;
+wire       wps_n = ~readonly ^ ch_state;
+wire       tr00_sense_n;
 
 c1541_logic c1541_logic
 (
@@ -116,23 +119,22 @@ c1541_logic c1541_logic
 	.mode(mode),
 	.stp(stp),
 	.mtr(mtr),
+	.soe(soe),
 	.freq(freq),
 	.sync_n(sync_n),
 	.byte_n(byte_n),
-	.wps_n(~readonly ^ ch_state),
-	.tr00_sense_n(|track),
+	.wps_n(wps_n),
+	.tr00_sense_n(tr00_sense_n),
 	.act(act)
 );
 
-wire [7:0] buff_dout;
-wire [7:0] buff_din;
+wire       buff_dout;
+wire       buff_din;
 wire       buff_we;
 wire [7:0] gcr_do;
 wire [7:0] gcr_di;
 wire       sync_n;
 wire       byte_n;
-wire [4:0] sector;
-wire [7:0] byte_addr;
 
 c1541_gcr c1541_gcr
 (
@@ -141,20 +143,15 @@ c1541_gcr c1541_gcr
 	.dout(gcr_do),
 	.din(gcr_di),
 	.mode(mode),
-	.mtr(mtr),
 	.freq(freq),
+	.soe(soe),
+	.wps_n(wps_n),
 	.sync_n(sync_n),
 	.byte_n(byte_n),
 
-	.track(track),
-	.sector(sector),
-
-	.byte_addr(byte_addr),
 	.ram_do(buff_dout),
 	.ram_di(buff_din),
-	.ram_we(buff_we),
-
-	.ram_ready(~sd_busy)
+	.ram_we(buff_we)
 );
 
 c1541_track c1541_track
@@ -170,66 +167,18 @@ c1541_track c1541_track
 	.sd_buff_din(sd_buff_din),
 	.sd_buff_wr(sd_buff_wr),
 
-	.buff_addr(byte_addr),
 	.buff_dout(buff_dout),
 	.buff_din(buff_din),
 	.buff_we(buff_we),
 
-	.save_track(save_track),
-	.change(disk_change),
-	.track(track),
-	.sector(sector),
+	.disk_change(disk_change),
+	.stp(stp),
+	.mtr(mtr),
+	.act(act),
+	.tr00_sense_n(tr00_sense_n),
 
 	.clk(clk_c1541),
 	.reset(reset),
 	.busy(sd_busy)
 );
-
-reg [5:0] track;
-reg       save_track;
-always @(posedge clk_c1541) begin
-	reg       track_modified;
-	reg [6:0] half_track;
-	reg [1:0] stp_r;
-	reg       act_r;
-
-	stp_r <= stp;
-	act_r <= act;
-	save_track <= 0;
-	track <= half_track[6:1];
-
-	if (buff_we) track_modified <= 1;
-	if (disk_change) track_modified <= 0;
-
-	if (reset) begin
-		half_track <= 36;
-		track_modified <= 0;
-	end else begin
-		if (mtr) begin
-			if ( (stp_r == 0 & stp == 1)
-				| (stp_r == 1 & stp == 2)
-				| (stp_r == 2 & stp == 3)
-				| (stp_r == 3 & stp == 0)) begin
-				if (half_track < 80) half_track <= half_track + 1'b1;
-				save_track <= track_modified;
-				track_modified <= 0;
-			end
-
-			if ( (stp_r == 0 & stp == 3)
-				| (stp_r == 3 & stp == 2)
-				| (stp_r == 2 & stp == 1)
-				| (stp_r == 1 & stp == 0)) begin
-				if (half_track > 1) half_track <= half_track - 1'b1;
-				save_track <= track_modified;
-				track_modified <= 0;
-			end
-		end
-
-		if (act_r & ~act) begin		// stopping activity
-			save_track <= track_modified;
-			track_modified <= 0;
-		end
-	end
-end
-
 endmodule

--- a/rtl/c1541/c1541_sd.v
+++ b/rtl/c1541/c1541_sd.v
@@ -189,37 +189,37 @@ reg [5:0] track;
 reg       save_track;
 always @(posedge clk_c1541) begin
 	reg       track_modified;
-	reg [6:0] track_num;
+	reg [6:0] half_track;
 	reg [1:0] stp_r;
 	reg       act_r;
 
 	stp_r <= stp;
 	act_r <= act;
 	save_track <= 0;
-	track <= track_num[6:1];
+	track <= half_track[6:1];
 
 	if (buff_we) track_modified <= 1;
 	if (disk_change) track_modified <= 0;
 
 	if (reset) begin
-		track_num <= 36;
+		half_track <= 36;
 		track_modified <= 0;
 	end else begin
 		if (mtr) begin
-			if ( (stp_r == 0 & stp == 2)
-				| (stp_r == 2 & stp == 1)
-				| (stp_r == 1 & stp == 3)
+			if ( (stp_r == 0 & stp == 1)
+				| (stp_r == 1 & stp == 2)
+				| (stp_r == 2 & stp == 3)
 				| (stp_r == 3 & stp == 0)) begin
-				if (track_num < 80) track_num <= track_num + 1'b1;
+				if (half_track < 80) half_track <= half_track + 1'b1;
 				save_track <= track_modified;
 				track_modified <= 0;
 			end
 
 			if ( (stp_r == 0 & stp == 3)
-				| (stp_r == 2 & stp == 0)
-				| (stp_r == 1 & stp == 2)
-				| (stp_r == 3 & stp == 1)) begin
-				if (track_num > 1) track_num <= track_num - 1'b1;
+				| (stp_r == 3 & stp == 2)
+				| (stp_r == 2 & stp == 1)
+				| (stp_r == 1 & stp == 0)) begin
+				if (half_track > 1) half_track <= half_track - 1'b1;
 				save_track <= track_modified;
 				track_modified <= 0;
 			end

--- a/rtl/c1541/c1541_track.sv
+++ b/rtl/c1541/c1541_track.sv
@@ -219,6 +219,11 @@ always @(posedge clk) begin
 	else
 	if(busy) begin
 		if(old_ack && ~ack) begin
+			if((!metadata_track && !saving && cur_half_track != half_track)) begin
+				// Was loading, but track changed. Stop so a new read is initiated.
+				busy <= 0;
+			end
+			else
 			if(( metadata_track && lba_count != 4'b1) ||
 			   (!metadata_track && lba_count != 4'b1111)) begin
 				// Not done yet ? Load/writeback next LBA.

--- a/rtl/c1541/c1541_track.sv
+++ b/rtl/c1541/c1541_track.sv
@@ -175,7 +175,7 @@ always @(posedge clk) begin
 	if (~old_disk_change && disk_change) ready <= 1;
 
 	old_buff_din <= buff_din;
-	if (mtr) begin
+	if (ready && mtr) begin
 		if (clk_counter == clk_counter_max_integer) begin
 			// number of 32MHz clock periods until next bit is: next_delay = track_delay * 2 + (32 * 2 - 1).next_delay_fract
 			// "32" because track_delay is stored offset by -32.

--- a/rtl/c1541/c1541_track.sv
+++ b/rtl/c1541/c1541_track.sv
@@ -192,7 +192,7 @@ always @(posedge clk) begin
 					wr <= 1;
 					busy <= 1;
 				end
-				is_current_lba_dirty <= buff_we & ~disk_change;
+				is_current_lba_dirty <= 0;
 			end
 			buff_din_latched <= buff_din_posedge;
 			rnd_reg <= rnd;

--- a/rtl/c1541/convert.py
+++ b/rtl/c1541/convert.py
@@ -104,7 +104,8 @@ class I64(BaseImage):
         gcr_half_track_dict = {}
         for half_track_number, (track_speed_and_delay_integer, _, track_length, _, _) in enumerate(track_metadata_list):
             track = istream.read(cls._TRACK_LENGTH)
-            if track != cls._BLANK_TRACK:
+            # Emit mandatory and non-empty tracks
+            if (half_track_number & 1 == 0 and half_track_number < 70) or track != cls._BLANK_TRACK:
                 gcr_half_track_dict[half_track_number] = (track[:track_length], track_speed_and_delay_integer >> 6)
         return cls(gcr_half_track_dict)
 

--- a/rtl/c1541/convert.py
+++ b/rtl/c1541/convert.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python
+from __future__ import division
+from collections import defaultdict
+from itertools import count
+import math
+import os
+import struct
+import sys
+
+class BaseImage(object):
+    _SIDE_TRACK_COUNT = 84
+    _SPEED_TO_BYTE_LENGTH_LIST = [6250, 6666, 7142, 7692]
+    _DEFAULT_SPEED_LIST = [3] * (17 - 0) * 2 + [2] * (24 - 17) * 2 + [1] * (30 - 24) * 2 + [0] * (42 - 30) * 2
+    assert len(_DEFAULT_SPEED_LIST) == 84
+
+    def __init__(self, gcr_half_track_dict):
+        self.gcr_half_track_dict = gcr_half_track_dict
+
+    def _getHalfTrackDataAndSpeed(self, half_track_number):
+        try:
+            speed = self._DEFAULT_SPEED_LIST[half_track_number]
+        except IndexError:
+            speed = None
+        return self.gcr_half_track_dict.get(half_track_number, (None, speed))
+
+    @classmethod
+    def read(cls, istream):
+        raise NotImplementedError
+
+    def write(self, ostream):
+        raise NotImplementedError
+
+class I64(BaseImage):
+    """
+    file:
+      84 * track_data + 84 * track_metadata
+    track_data:
+      0x2000 bytes whose bits represent magnetic flux changes
+    track_metadata:
+      speed + clock_count + track_length + previous_track_length_ratio + next_track_length_ratio
+    speed (2 bits):
+      Track speed zone (0, 1, 2, 3, 0 being slowest).
+      Only intended to be used to reconstruct G64 image.
+    clock_count (14 bits):
+      The number, minus 32, of 16MHz clock pulses a "1" bit lasts.
+      Stored as fixed-point: 6 bits for integer part followed by 8 bits for fractional part.
+    track_length (16 bits):
+      The number of bytes in that track.
+    *_track_length_ratio (16 bits each)
+      Fixed-point ratio between this track and...
+      previous_*: the one with an immediately inferior track number
+      next_*: the one with an immediately superior track number
+    """
+
+    # Fixed values (drive design)
+    _BASE_CLOCK_FREQUENCY = 16e6 # Hz
+    _SPINDLE_ROTATION_FREQUENCY = 5 # Hz, 300rpm = 5Hz
+    _TIME_DOMAIN_FILTER_RESISTOR = 22 # kOhm +/- 5%
+    _TIME_DOMAIN_FILTER_CAPACITOR = 330 # pF +/- 5%
+    _TIME_DOMAIN_FILTER_K = 0.37 # from Fairchild 9602 datasheet, page 5 figure 6
+    _TIME_DOMAIN_FILTER_PULSE_WIDTH = (
+        _TIME_DOMAIN_FILTER_K *
+        _TIME_DOMAIN_FILTER_RESISTOR *
+        _TIME_DOMAIN_FILTER_CAPACITOR *
+        (1 + 1 / _TIME_DOMAIN_FILTER_RESISTOR)
+    ) # ns, +/- 10%, formula from Fairchild 9602 datasheet
+    # XXX: Taking typical values (so ignoring component precision)
+    _TIME_DOMAIN_FILTER_PULSE_BASE_CLOCK_WIDTH = _BASE_CLOCK_FREQUENCY * (_TIME_DOMAIN_FILTER_PULSE_WIDTH * 1e-9)
+    # At the slowest speed (zone 0), it takes 32 clock cycles to shift a 1 and 64 to shift a 0.
+    # This is because all a magnetic head can read is a flux change (for a 1).
+    # Absence of flux change is handled as a timeout, so it is longer - twice longer in this drive's case.
+    _ONE_SHIFT_CLOCK_CYCLE_COUNT = 32
+    _ZERO_SHIFT_CLOCK_CYCLE_COUNT = 64
+    # Time domain pulse must be longer that a "1", but shorter than a "0".
+    # In reality, given component values this is around 45 clock cycles. At +/- 20%
+    # (10% from 6902 chip, 5% from capacitor, 5% from resistor), this is from 36 to 54,
+    # so this assertion is more about documenting circuit and as a rough sanity check
+    # than an expected error case.
+    assert _ONE_SHIFT_CLOCK_CYCLE_COUNT < _TIME_DOMAIN_FILTER_PULSE_BASE_CLOCK_WIDTH < _ZERO_SHIFT_CLOCK_CYCLE_COUNT, _TIME_DOMAIN_FILTER_PULSE_BASE_CLOCK_WIDTH
+    del _BASE_CLOCK_FREQUENCY
+    del _SPINDLE_ROTATION_FREQUENCY
+    del _TIME_DOMAIN_FILTER_RESISTOR
+    del _TIME_DOMAIN_FILTER_CAPACITOR
+    del _TIME_DOMAIN_FILTER_K
+    del _TIME_DOMAIN_FILTER_PULSE_WIDTH
+
+    # 16 - x: number of 16MHz clock pulses needed to overflow UE6 for speed zone "x"
+    # 2: after 2 UE6 overflows a bit is clocked in/out of the bit shift registers by UF4
+    _STANDARD_ONE_DELAY_LIST = tuple([(16 - x) * 2 for x in (0, 1, 2, 3)])
+    _STANDARD_ZERO_DELAY_LIST = tuple([(16 - x) * 4 for x in (0, 1, 2, 3)])
+    _MIN_ONE_DELAY = math.ceil(_TIME_DOMAIN_FILTER_PULSE_BASE_CLOCK_WIDTH)
+
+    _TRACK_LENGTH = 2 ** max(BaseImage._SPEED_TO_BYTE_LENGTH_LIST).bit_length()
+    assert _TRACK_LENGTH == 0x2000, _TRACK_LENGTH
+    _BLANK_TRACK = '\x00' * _TRACK_LENGTH
+    _METADATA_BLOCK_OFFSET = _TRACK_LENGTH * BaseImage._SIDE_TRACK_COUNT
+    _FILE_SIZE = _METADATA_BLOCK_OFFSET + 0x400 # Add one LBA for metadata: 84 * 4 < 0x200
+
+    @classmethod
+    def read(cls, istream):
+        istream.seek(cls._METADATA_BLOCK_OFFSET)
+        track_metadata_list = [struct.unpack('>BBHHH', istream.read(8)) for _ in range(cls._SIDE_TRACK_COUNT)]
+        istream.seek(0)
+        gcr_half_track_dict = {}
+        for half_track_number, (track_speed_and_delay_integer, _, track_length, _, _) in enumerate(track_metadata_list):
+            track = istream.read(cls._TRACK_LENGTH)
+            if track != cls._BLANK_TRACK:
+                gcr_half_track_dict[half_track_number] = (track[:track_length], track_speed_and_delay_integer >> 6)
+        return cls(gcr_half_track_dict)
+
+    def write(self, ostream):
+        track_metadata_list = []
+        next_track_length = previous_track_length = None
+        for half_track_number in range(self._SIDE_TRACK_COUNT):
+            track, speed = self._getHalfTrackDataAndSpeed(half_track_number)
+            if track:
+                track_length = len(track)
+                assert track_length <= self._TRACK_LENGTH, (half_track_number, track_length)
+            else:
+                track_length = len(self._BLANK_TRACK) if previous_track_length is None else previous_track_length
+                track = self._BLANK_TRACK
+            assert next_track_length in (track_length, None), (half_track_number, next_track_length, track_length)
+            delay = self._SPEED_TO_BYTE_LENGTH_LIST[speed] / track_length * self._STANDARD_ZERO_DELAY_LIST[speed]
+            assert self._TIME_DOMAIN_FILTER_PULSE_BASE_CLOCK_WIDTH < delay < self._STANDARD_ONE_DELAY_LIST[speed] + self._STANDARD_ZERO_DELAY_LIST[speed], (half_track_number, delay, speed)
+            delay_integer, delay_fractional = divmod(delay, 1)
+            if previous_track_length is None:
+                previous_track_length = track_length
+            next_track, _ = self._getHalfTrackDataAndSpeed(half_track_number + 1)
+            next_track_length = len(next_track) if next_track else track_length
+            track_metadata_list.append(struct.pack(
+                '>BBHHH',
+                speed << 6 | (int(delay_integer) - self._ONE_SHIFT_CLOCK_CYCLE_COUNT),
+                int(delay_fractional * 256),
+                track_length,
+                int(round(previous_track_length / track_length * 2**15)),
+                int(round(next_track_length / track_length * 2**15)),
+            ))
+            previous_track_length = track_length
+            ostream.write(track)
+            ostream.write('\x00' * (self._TRACK_LENGTH - len(track)))
+        assert self._METADATA_BLOCK_OFFSET == ostream.tell()
+        ostream.write(''.join(track_metadata_list))
+        ostream.write('\x00' * (self._FILE_SIZE - ostream.tell()))
+
+class G64(BaseImage):
+    _MAGIC = 'GCR-1541\x00'
+
+    @classmethod
+    def read(cls, istream):
+        magic = istream.read(len(cls._MAGIC))
+        assert magic == cls._MAGIC, repr(magic)
+        track_count, max_track_length = struct.unpack('<BH', istream.read(3))
+        track_data_offset_list = []
+        track_speed_offset_list = []
+        for offset_list in (
+            track_data_offset_list,
+            track_speed_offset_list,
+        ):
+            for _ in range(track_count):
+                offset_list.append(struct.unpack('<I', istream.read(4))[0])
+        gcr_half_track_dict = {}
+        for half_track_number, track_data_offset in enumerate(track_data_offset_list):
+            if not track_data_offset:
+                continue
+            istream.seek(track_data_offset)
+            track_length = struct.unpack('<H', istream.read(2))[0]
+            assert track_length <= max_track_length, (half_track_number, track_length)
+            gcr_half_track_dict[half_track_number] = [istream.read(track_length), None]
+        # XXX: no speed support, just check the value is standard
+        for half_track_number, track_speed_offset in enumerate(track_speed_offset_list):
+            half_track_length = len(gcr_half_track_dict.get(half_track_number, ''))
+            if not half_track_length:
+                continue
+            if track_speed_offset > 3:
+                istream.seek(track_speed_offset)
+                track_speed_set = set()
+                speed_data = [
+                    struct.unpack('B', x)[0]
+                    for x in istream.read((half_track_length + 3) // 4)
+                ]
+                for data_byte_index in range(half_track_length):
+                    speed_byte_index, half_shift = divmod(data_byte_index, 4)
+                    track_speed_set.add((speed_data[speed_byte_index] >> (8 - half_shift * 2)) & 0x3)
+                if len(track_speed_set):
+                    print 'Warning half track %i: multiple speeds used: %r' % (half_track_number, track_speed_set)
+                    track_speed = max(track_speed_set)
+            else:
+                track_speed = track_speed_offset
+            gcr_half_track_dict[half_track_number][1] = track_speed
+        return cls(gcr_half_track_dict)
+
+    def write(self, ostream):
+        ostream.write(self._MAGIC)
+        track_count = self._SIDE_TRACK_COUNT
+        assert len(self.gcr_half_track_dict) <= track_count
+        max_track_length = 7928
+        assert max(len(x) for x, _ in self.gcr_half_track_dict.values()) <= max_track_length, ([len(x) for x, _ in self.gcr_half_track_dict.values()], max_track_length)
+        ostream.write(struct.pack('<BH', track_count, max_track_length))
+        base_offset = current_offset = ostream.tell() + 4 * 2 * track_count
+        half_track_offset_list = []
+        speed_list = []
+        for half_track_number in range(track_count):
+            track_data, track_speed = self._getHalfTrackDataAndSpeed(half_track_number)
+            if track_data:
+                offset = current_offset
+                current_offset += max_track_length + 2 # +2 for the length bytes header
+                half_track_offset_list.append((half_track_number, offset))
+            else:
+                speed = 0 # Not really meaningful ?
+                offset = 0
+            speed_list.append(track_speed)
+            ostream.write(struct.pack('<I', offset))
+        for speed in speed_list:
+            ostream.write(struct.pack('<I', speed))
+        assert ostream.tell() == base_offset, (ostream.tell(), base_offset)
+        for half_track_number, offset in half_track_offset_list:
+            track_data, _ = self.gcr_half_track_dict[half_track_number]
+            assert offset == ostream.tell(), (half_track_number, offset, ostream.tell())
+            ostream.write(struct.pack('<H', len(track_data)))
+            ostream.write(track_data)
+            if len(track_data) < max_track_length:
+                # XXX: vice is not consistent in post-track content: new disks contain
+                # 0x55, modified tracks contain 0x00. 0x55 is already naturally present
+                # and is valid GCR, so use this.
+                ostream.write('\x55' * (max_track_length - len(track_data)))
+
+MASK_LIST = (0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01)
+def toBitString(byte_string):
+    # XXX: ultra-low-tech, takes ~8 times the memory, but simple
+    result = []
+    append = result.append
+    for data_byte in byte_string:
+        data_byte = ord(data_byte)
+        append(''.join('1' if data_byte & mask else '0' for mask in MASK_LIST))
+    return ''.join(result)
+
+SHIFT_LIST = (7, 6, 5, 4, 3, 2, 1, 0)
+def toByteString(bit_string):
+    result = []
+    append = result.append
+    while bit_string:
+        one_byte, bit_string = bit_string[:8], bit_string[8:]
+        if len(one_byte) != 8:
+            one_byte += '1' * (8 - len(one_byte))
+        append(chr(sum(int(x) << y for x, y in zip(one_byte, SHIFT_LIST))))
+    return ''.join(result)
+
+class D64(BaseImage):
+    _TRACK_SECTOR_COUNT_LIST = [21] * (17 - 0) + [19] * (24 - 17) + [18] * (30 - 24) + [17] * (42 - 30)
+    _POST_DATA_GAP_LENGTH_LIST = [8] * (17 - 0) + [17] * (24 - 17) + [12] * (30 - 24) + [9] * (42 - 30)
+    # BAM sector offset 162 & 163 have the disk ID
+    _ID_OFFSET = 0x165a2
+    _GCR_SYNC = '\xff' * 5
+    _GCR_GAP = '\x55'
+    _GCR_LIST = [
+        0b01010, 0b01011,
+        0b10010, 0b10011,
+        0b01110, 0b01111,
+        0b10110, 0b10111,
+        0b01001, 0b11001,
+        0b11010, 0b11011,
+        0b01101, 0b11101,
+        0b11110, 0b10101,
+    ]
+    _GCR_DICT = {y: x for x, y in enumerate(_GCR_LIST)}
+    _SYNC_BIT_STRING = '1' * 10
+    _EMPTY_BLOCK = '\x00' * 256
+
+    # Error block codes
+    _STATUS_OK = 0
+    _STATUS_NO_HEADER = 20
+    _STATUS_NO_SYNC = 21
+    _STATUS_NO_DATA = 22
+    _STATUS_BAD_DATA = 23
+    _STATUS_BAD_HEADER = 27
+    _STATUS_ID_MISMATCH = 29
+
+    @classmethod
+    def _gcr_encode(cls, data):
+        gcr_mask = [2 ** x - 1 for x in range(1, 9)]
+        result = []
+        gcr = 0
+        gcr_bitcount = 0
+        gcr_list = cls._GCR_LIST
+        #import pdb; pdb.set_trace()
+        for data_byte in data:
+            data_byte = ord(data_byte)
+            gcr <<= 10
+            gcr += (gcr_list[data_byte >> 4] << 5) + gcr_list[data_byte & 0xf]
+            gcr_bitcount += 10
+            while gcr_bitcount >= 8:
+                gcr_bitcount -= 8
+                result.append(chr((gcr >> gcr_bitcount) & 0xff))
+            gcr &= gcr_mask[gcr_bitcount]
+        assert not gcr_bitcount, (gcr_bitcount, gcr, len(data), repr(data), repr(''.join(result)))
+        return ''.join(result)
+
+    @classmethod
+    def _gcr_decode(cls, data):
+        gcr_mask = [2 ** x - 1 for x in range(10)]
+        result = []
+        gcr = 0
+        gcr_bitcount = 0
+        gcr_dict = cls._GCR_DICT
+        for gcr_byte in data:
+            gcr_byte = ord(gcr_byte)
+            gcr <<= 8
+            gcr += gcr_byte
+            gcr_bitcount += 8
+            while gcr_bitcount >= 10:
+                gcr_bitcount -= 10
+                result.append(chr(
+                    (gcr_dict.get((gcr >> (gcr_bitcount + 5)) & 0x1f, 0) << 4) +
+                    gcr_dict.get((gcr >> gcr_bitcount) & 0x1f, 0),
+                ))
+            gcr &= gcr_mask[gcr_bitcount]
+        return ''.join(result)
+
+    @classmethod
+    def read(cls, istream):
+        istream.seek(cls._ID_OFFSET)
+        disk_id = ''.join(reversed(istream.read(2)))
+        disk_id_sum = ord(disk_id[0]) ^ ord(disk_id[1])
+        bad_disk_id = disk_id[0] + chr(ord(disk_id[1]) ^ 1)
+        bad_disk_id_sum = ord(bad_disk_id[0]) ^ ord(bad_disk_id[1])
+        istream.seek(0, 2)
+        track_count, error_block_offset = {
+            174848: (35, None),
+            175531: (35, 174848),
+            196608: (40, None),
+            197376: (40, 196608),
+            205312: (42, None),
+            206114: (42, 205312),
+            # D71
+            349696: (70, None),
+            351062: (70, 349696),
+        }[istream.tell()]
+        if track_count > 42:
+            print 'Warning: no double-sided disk support yet, ignoring tracks above 35'
+            track_count = 35
+        if error_block_offset:
+            istream.seek(error_block_offset)
+            error_list = [
+                [
+                    ord(istream.read(1))
+                    for _ in range(cls._TRACK_SECTOR_COUNT_LIST[track_number])
+                ]
+                for track_number in range(track_count)
+            ]
+        else:
+            error_list = [
+                [
+                    cls._STATUS_OK
+                    for _ in range(cls._TRACK_SECTOR_COUNT_LIST[track_number])
+                ]
+                for track_number in range(track_count)
+            ]
+        istream.seek(0)
+        gcr_half_track_dict = {}
+        for track_number in range(track_count):
+            track_error_list = error_list[track_number]
+            if cls._STATUS_NO_SYNC in track_error_list:
+                if len(set(track_error_list)) == 1:
+                    # No sync on whole track ? leave it blank
+                    continue
+                print 'Warning: image contains tracks with a mix of "NO SYNC" and other block statuses, ignoring "NO SYNC"'
+            gcr_track = []
+            for block_number in range(cls._TRACK_SECTOR_COUNT_LIST[track_number]):
+                block_error = track_error_list[block_number]
+                block_data = istream.read(256)
+                assert len(block_data) == 256, (track_number, block_number)
+                data_checksum = 0
+                if block_error == cls._STATUS_BAD_DATA:
+                    data_checksum += 1
+                if block_error == cls._STATUS_ID_MISMATCH:
+                    block_disk_id = bad_disk_id
+                    block_disk_id_sum = bad_disk_id_sum
+                else:
+                    block_disk_id = disk_id
+                    block_disk_id_sum = disk_id_sum
+                for data_byte in block_data:
+                    data_checksum ^= ord(data_byte)
+                gap_length = cls._POST_DATA_GAP_LENGTH_LIST[track_number]
+                gcr_track.append(
+                    cls._GCR_SYNC + cls._gcr_encode(
+                        ('\x00' if block_error == cls._STATUS_NO_HEADER else '\x08') +
+                        chr(
+                            (track_number + 1) ^
+                            block_number ^
+                            block_disk_id_sum ^
+                            (1 if block_error == cls._STATUS_BAD_HEADER else 0)
+                        ) +
+                        chr(block_number) +
+                        chr(track_number + 1) +
+                        block_disk_id +
+                        '\x0f\x0f', # To get to a multiple of 4 bytes for GCR encoding
+                    ) + cls._GCR_GAP * 9 +
+                    cls._GCR_SYNC + cls._gcr_encode(
+                        ('\x00' if block_error == cls._STATUS_NO_DATA else '\x07') +
+                        block_data +
+                        chr(data_checksum) +
+                        # XXX: VICE uses 0x00 padding
+                        '\x00\x00', #'\x0f\x0f', # To get to a multiple of 4 bytes for GCR encoding
+                    ) + cls._GCR_GAP * gap_length,
+                )
+            # Double is the new half.
+            half_track_number = track_number * 2
+            gcr_track = ''.join(gcr_track)
+            speed = cls._DEFAULT_SPEED_LIST[half_track_number]
+            track_usable_length = cls._SPEED_TO_BYTE_LENGTH_LIST[speed]
+            if len(gcr_track) < track_usable_length:
+                gcr_track += '\x55' * (track_usable_length - len(gcr_track))
+            gcr_half_track_dict[half_track_number] = (gcr_track, speed)
+        return cls(gcr_half_track_dict)
+
+    def write(self, ostream):
+        for half_track_number in range(self._SIDE_TRACK_COUNT):
+            if half_track_number & 1:
+                continue
+            # Half is the new double.
+            track_number = half_track_number // 2
+            track_sector_count = self._TRACK_SECTOR_COUNT_LIST[track_number]
+            track_gcr_data, speed = self._getHalfTrackDataAndSpeed(half_track_number)
+            if not track_gcr_data:
+                ostream.write(self._EMPTY_BLOCK * track_sector_count)
+                continue
+            assert speed == self._DEFAULT_SPEED_LIST[half_track_number], 'D64 cannot contain non-standard speed tracks: half-track %i speed %i, standard speed %i' % (
+                half_track_number,
+                speed,
+                self._DEFAULT_SPEED_LIST[half_track_number],
+            )
+            # Make track easy to manipulate at individual bit level.
+            track_gcr_bit_string = toBitString(track_gcr_data.rstrip('\x00'))
+            # Align to beginning of first sync mark.
+            if self._SYNC_BIT_STRING not in track_gcr_bit_string:
+                print 'Warning half track %i: no sync mark, assuming empty' % half_track_number
+                ostream.write(self._EMPTY_BLOCK * track_sector_count)
+                continue
+            first_sync_mark_pos = track_gcr_bit_string.index(self._SYNC_BIT_STRING)
+            track_gcr_bit_string = track_gcr_bit_string[first_sync_mark_pos:] + track_gcr_bit_string[:first_sync_mark_pos]
+            # Split on sync marks.
+            between_sync_chunk_list = [x.strip('1') for x in track_gcr_bit_string.split(self._SYNC_BIT_STRING)]
+            decoded_chunk_list = []
+            for between_sync_chunk in between_sync_chunk_list:
+                if not between_sync_chunk:
+                    continue
+                between_sync_chunk = toByteString(between_sync_chunk)
+                decoded_chunk_list.append(self._gcr_decode(between_sync_chunk))
+            # If first chunk is of data type, move it at the end of the list (hopefully behind its header)
+            if decoded_chunk_list[0][0] == '\x07':
+                decoded_chunk_list.append(decoded_chunk_list.pop(0))
+            disk_dict = defaultdict(lambda: defaultdict(list))
+            decoded_chunk_list.reverse() # Because it's faster to pop from end of list
+            while decoded_chunk_list:
+                decoded_chunk = decoded_chunk_list.pop()
+                stripped_decoded_chunk = decoded_chunk.rstrip('\x0f')
+                if stripped_decoded_chunk[0] != '\x08' or len(stripped_decoded_chunk) < 6:
+                    print 'Warning half track %i: not a (complete) block header: %r' % (half_track_number, decoded_chunk)
+                    continue
+                _, checksum, block_number, block_track_number, disk_id1, disk_id2 = struct.unpack('BBBBcc', stripped_decoded_chunk[:6])
+                if block_track_number != track_number + 1:
+                    print 'Warning half track %i: god a block claiming to be from track %i' % (half_track_number, track_number + 1)
+                    continue
+                if checksum != block_number ^ block_track_number ^ ord(disk_id1) ^ ord(disk_id2):
+                    print 'Warning half track %i: bad header checksum: %02x != %02x + %02x + %02x + %02x' % (half_track_number, checksum, block_number, block_track_number, ord(disk_id1), ord(disk_id2))
+                    continue
+                decoded_chunk = decoded_chunk_list.pop()
+                if decoded_chunk[0] != '\x07' or len(decoded_chunk) < 258:
+                    print 'Warning half track %i: not a (complete) data block: %r' % (half_track_number, decoded_chunk)
+                    continue
+                data_checksum = ord(decoded_chunk[257])
+                data = decoded_chunk[1:257]
+                recomputed_data_checksum = 0
+                for data_byte in data:
+                    recomputed_data_checksum ^= ord(data_byte)
+                if recomputed_data_checksum & 0xff != data_checksum:
+                    print 'Warning half track %i: bad data checksum: %02x != %02x' % (half_track_number, data_checksum, recomputed_data_checksum)
+                    continue
+                disk_dict[disk_id1 + disk_id2][block_number].append(data)
+            # If disk was reformated, it is possible a few headers from previous disk survived in the gaps.
+            # Pick the id which has most sectors. (one must be the clearly most common)
+            if not disk_dict:
+                print 'Warning half track %i: no valid block found, assuming empty' % half_track_number
+                ostream.write(self._EMPTY_BLOCK * track_sector_count)
+                continue
+            block_dict = sorted(disk_dict.values(), key=lambda x: len(x))[-1]
+            block_list = []
+            for block_id in range(track_sector_count):
+                block, = block_dict.get(block_id, (self._EMPTY_BLOCK, )) # Detect aliased blocks
+                block_list.append(block)
+            ostream.write(''.join(block_list))
+
+EXTENSION_TO_CLASS = {
+    '.d64': D64,
+    '.d71': D64,
+    '.g64': G64,
+    '.i64': I64,
+}
+def main(infile_name, outfile_name):
+    if os.path.exists(outfile_name):
+        raise ValueError('Not overwriting %r' % outfile_name)
+    infile_class = EXTENSION_TO_CLASS[os.path.splitext(infile_name)[1].lower()]
+    outfile_class = EXTENSION_TO_CLASS[os.path.splitext(outfile_name)[1].lower()]
+    with open(infile_name, 'r') as infile:
+        try:
+            with open(outfile_name, 'w') as outfile:
+                outfile_class(infile_class.read(infile).gcr_half_track_dict).write(outfile)
+        except Exception:
+            os.unlink(outfile_name)
+            raise
+
+if __name__ == '__main__':
+    main(*sys.argv[1:])

--- a/rtl/lfsr.v
+++ b/rtl/lfsr.v
@@ -1,0 +1,16 @@
+
+module lfsr(
+   output [N-1:0] rnd
+);
+
+parameter N = 63;
+
+lcell lc0(~(rnd[N - 1] ^ rnd[N - 3] ^ rnd[N - 4] ^ rnd[N - 6] ^ rnd[N - 10]), rnd[0]);
+generate
+	genvar i;
+	for (i = 0; i <= N - 2; i = i + 1) begin : lcn
+		lcell lc(rnd[i], rnd[i + 1]);
+	end
+endgenerate
+
+endmodule


### PR DESCRIPTION
This may be a long-lived merge request, as there may be (much) more to do before it can be reasonably merged.

I do not think incremental improvements (improve, merge, improve more, merge, ...) will work well here, because (so far) of the disk image format change: the core expects data in a different format than previous version, so unless it can handle the conversion internally it will be incompatible with older MiSTer versions (hard-processor side). Symetrically, if the number of expected image formats increase (from one improvement to the next, more data or a completely different image organisation may be needed), more breakages will exist.

Here is a rough and un-ordered TODO-list:
- [x] add support for longer tracks (see below)
- [x] add support for weak bits (see bellow)
- [x] check if adding support for read speed mismatch is needed, and if so, add it (maybe not needed, but I understand enough of the drive that I added it anyway)
- [ ] get [vice drive test suite](https://sourceforge.net/p/vice-emu/code/HEAD/tree/testprogs/drive/) to pass
  - [x] bitnax
  - [x] defaults (VIA6522)
  - [ ] diskchange (incorrect number of write_n pulses, **low priority bug**)
  - [x] diskid
  - [x] format
  - [x] rpm
  - [x] scan{35,40,42}{,err}.{d,g}64
  - [x] skew
  - [x] viavarious (VIA6522)
    - [x] via1
    - [x] via2
    - [x] via3
    - [x] via3a
    - [x] via4
    - [x] via5
    - [x] via9
    - [x] via10
    - [x] via11
    - [x] via12
    - [x] via13
    - [x] via14
- [ ] make [Jani c1541 test cartridge](http://blog.worldofjani.com/?p=2180) happy
  - [ ] track alignment test (sometime freezes)
  - [ ] fast format (incomplete write-back, requires writing back much earlier - ex: tracking LBA dirtyfication within a track, and writing back to hard processor as soon as drive left the LBA) (**low priority bug**)
  - [x] speed check (rpm detection, almost same as vice test suite but slightly different results - but within tolerances)
  - [x] performance test
  - more ?
- [ ] get copy protections to pass (others may just not be possible to satisfy, maybe the g64 images I have are just not accurate enough to satisfy these copy protections)
  - [x] fat tracks
  - [ ] mindscape
  - [x] PirateSlayer v1
  - [x] PirateSlayer v2
  - [x] PirateBusters
  - [x] RADWAR
  - [ ] Rapidlok v1
  - [ ] Rapidlok v2
  - [ ] Rapidlok v3
  - [ ] Rapidlok v4
  - [ ] Rapidlok v5
  - [ ] Rapidlok v6
  - [ ] Rapidlok v7
  - [x] CYAN v1
  - [x] CYAN v2
  - [ ] V-MAX! v0
  - [ ] V-MAX! v1
  - [ ] V-MAX! v2
  - [ ] V-MAX! v3
  - [ ] Vorpal (early)
  - [ ] Vorpal (later)
  - [x] XEMAG 2.0
  - more ?
- [x] settle on an (at least) FGPA-internal image format, which depends on needed features
- [ ] implement image conversion in any way other than current python script, and revert image extension filter change: either on hard processor side (easy, fast, lots of memory, flexible), or on FPGA side (may require adding a dedicated micro CPU core, some ram, some rom, and some communication with the disk drive)

# Longer tracks

Current image format is a byte stream: bits are densely packed. To simulate the beginning of N+1 disk revolution, a standard-speed-dependent track length is hardcoded. This means that tracks written at faster speeds (hence containing more bits) will appear truncated (they wrap around too early).

What could be a better approach is to store tracks as sparse bit streams: wrap-around always happens at the same offset, each bit being a fraction of a complete disk revolution. This means that slower speed will skip some bits, but also that such bits must be taken into account when the track is read at faster speed. This leads to more realistic HDL (track bit stream and read bit shifts advance at their separate rhythm) but introduce mixed-timing HDL considerations that I am not yet able to tackle.

# Weak bits

Track bit stream is analog, and the magnetic flux may vary just barely enough to sometime trigger a read and other times not.

In my reading on copy protection mechanisms, I've seen this mixed with invalid GCR, especially more than 3 zeroes in a row. I feel they are separate mechanisms, where after 4 zeroes the drive will read a 1 bit, whether there is magnetic flux inversion on the disk or not. This happens in a deterministic fashion (a counter overflows), so I still fail to see how this would introduce the randomness that weak bits would (I would expect it should take quite a large number of bits before a one-bit alignment error would develop - but I do not have access to an actual drive for comparison). And because of this, it is not clear to me whether *actual* weak bits are used in copy protection, or just invalid GCR.

# Disk image format

D64 disk images do not contain half-tracks and only contain sector decoded payloads without their headers. So they cannot work with software relying on half tracks, invalid encodings and violations of headers and block structure. With an error block they can recreate some, but far from all.

G64 disk image contain half-tracks, and represent magnetic flux inversions on the disk, so they can represent (in theory) any disk. There are some details in how they cannot handle tracks with mixed bit speeds, but basically they are much more versatile.
The main problem with their support in HDL is their format is too flexible: there is a track offset table which is of variable length, tracks are of variable lengths and are concatenated. The variable length also means that it is hard to realistically emulate cross-track synchronisation: switching from a certain offset of a track to the next track needs to scale the offset to the length of the new track, otherwise both tracks will be out of phase - something some copy protections rely on. Also, tracks are not LBA-aligned, so boundaries need extra care to not erase neigbouring tracks.

So I designed an image format, *not* intended to be used for persistent disk image storage, but rather to be easy to use from HDL:
- there is a fixed-length block containing the metadata for all tracks: speed zone (ignored by HDL, useful to convert to other formats), number of 16MHz clock pulses per bit, length, pre-computed scaling ratio to inferior and superior track
- all tracks are present, LBA-aligned and LBA-sized
- tracks contain magnetic flux inversions (same as G64)

```
0x00000..0x01fff: Track 1
0x02000..0x03fff: Track 1.5
...
0xa6000..0xa7fff: Track 42.5
0xa8000..0xa8007: Track 1 metadata
0xa8008..0xa800f: Track 1.5 metadata
...
0xa81f8..0xa81ff: Track 42.5 metadata
```

Metadata structure (big endian):

```
6--65--------54--------43--------32--------21--------10--------0
3210987654321098765432109876543210987654321098765432109876543210
ssccccccccccccccllllllllllllllllrrrrrrrrrrrrrrrrRRRRRRRRRRRRRRRR
```

- `s`: speed zone (standard: 00 for innermost tracks, then 01, then 10, and 11 for outermost tracks)
- `c`: number, minus 32, of 16MHz clock cycles that a bit lasts, in 6.8 fixed-point format
- `l`: track length in bytes (technically it should be bits, but up to 7 extra bits in a track should make no measurable difference)
- `r`: the length of the track of immediately *inferior* index divided by the length of this track, in 1.15 fixed-point format
- `R`: the length of the track of immediately *superior* index divided by the length of this track, in 1.15 fixed-point format

For illustration purposes, here is what an entirely blank image with metadata for standard tracks (and with its metadata block padded with zeroes to fill the last LBA) looks like:
```
$ hd format_blank.i64
00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000a8000  d4 00 1e 0c 80 00 80 00  d4 00 1e 0c 80 00 80 00  |................|
*
000a8100  d4 00 1e 0c 80 00 80 00  d4 00 1e 0c 80 00 76 d9  |..............v.|
000a8110  98 00 1b e6 89 db 80 00  98 00 1b e6 80 00 80 00  |................|
000a8120  98 00 1b e6 80 00 80 00  98 00 1b e6 80 00 80 00  |................|
*
000a8170  98 00 1b e6 80 00 80 00  98 00 1b e6 80 00 77 78  |..............wx|
000a8180  5c 00 1a 0a 89 24 80 00  5c 00 1a 0a 80 00 80 00  |\....$..\.......|
000a8190  5c 00 1a 0a 80 00 80 00  5c 00 1a 0a 80 00 80 00  |\.......\.......|
*
000a81d0  5c 00 1a 0a 80 00 80 00  5c 00 1a 0a 80 00 78 03  |\.......\.....x.|
000a81e0  20 00 18 6a 88 85 80 00  20 00 18 6a 80 00 80 00  | ..j.... ..j....|
000a81f0  20 00 18 6a 80 00 80 00  20 00 18 6a 80 00 80 00  | ..j.... ..j....|
*
000a82a0  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
*
000a8400
```