### PR TITLE
video_vicII_656x.vhd: Fix sprite priority.

### DIFF
--- a/video_vicII_656x.vhd
+++ b/video_vicII_656x.vhd
@@ -1140,16 +1140,22 @@ calcBitmap: process(clk)
 			muxColor := "00";
 			muxSprite := (others => '-');
 			for i in 7 downto 0 loop
-				if (MPRIO(i) = '0') or (pixelBgFlag = '0') then
-					if MC(i) = '1' then
-						if MCurrentPixel(i) /= "00" then
+				if MC(i) = '1' then
+					if MCurrentPixel(i) /= "00" then
+						if (MPRIO(i) = '0') or (pixelBgFlag = '0') then
 							muxColor := MCurrentPixel(i);
-							muxSprite := to_unsigned(i, 3);
+						else
+							muxColor := "00";
 						end if;
-					elsif MCurrentPixel(i)(1) = '1' then
-						muxColor := "10";
 						muxSprite := to_unsigned(i, 3);
 					end if;
+				elsif MCurrentPixel(i)(1) = '1' then
+					if (MPRIO(i) = '0') or (pixelBgFlag = '0') then
+						muxColor := "10";
+					else
+						muxColor := "00";
+					end if;
+					muxSprite := to_unsigned(i, 3);
 				end if;
 			end loop;
 


### PR DESCRIPTION
If a lower-index background-priority (1) sprite's opaque pixel intersects
with a higher-index foreground-priority (0) sprite's opaque pixel, and the
screen bitmap has a foreground color at that same position, then the
screen bitmap's foreground color is visible.
This is counter-intuitive, as higher-index sprite's pixel alone would mask
the bitmap color, and adding another sprite top of it makes the bitmap
visible again, but this is how the VICII works.