### PR TITLE
Invert SID6581 filter output

### DIFF
--- a/rtl/sid6581/sid_mixer.vhd
+++ b/rtl/sid6581/sid_mixer.vhd
@@ -72,17 +72,17 @@ begin
             
             when 1 =>
                 if filter_hp='1' then
-                    mix_i <= sum_limit(mix_i, high_pass); 
+                    mix_i <= sub_limit(mix_i, high_pass);
                 end if;
                 
             when 2 =>
                 if filter_bp='1' then
-                    mix_i <= sum_limit(mix_i, band_pass); 
+                    mix_i <= sub_limit(mix_i, band_pass);
                 end if;
 
             when 3 =>
                 if filter_lp='1' then
-                    mix_i <= sum_limit(mix_i, low_pass); 
+                    mix_i <= sub_limit(mix_i, low_pass);
                 end if;
                 vol_s <= '0' & signed(c_volume_lut(to_integer(volume)));
 


### PR DESCRIPTION
As per the findings of Pex "Mahoney" Tufvesson the filter inverts
the waveforms, and this can be exploited to play back 8-bit samples.

This fixes the samples in the Musik Run/Stop demo which exploits
this property of the SID chip in detail.