### PR TITLE
Fix in some digital samples and a better palette (matching my real commodore).

### DIFF
--- a/rtl/fpga64_rgbcolor.vhd
+++ b/rtl/fpga64_rgbcolor.vhd
@@ -35,22 +35,23 @@ begin
 	process(index)
 	begin
 		case index is
-		when X"0" => r <= X"00"; g <= X"00"; b <= X"00";
-		when X"1" => r <= X"FF"; g <= X"FF"; b <= X"FF";
-		when X"2" => r <= X"81"; g <= X"33"; b <= X"38";
-		when X"3" => r <= X"75"; g <= X"ce"; b <= X"c8";
-		when X"4" => r <= X"8e"; g <= X"3c"; b <= X"97";
-		when X"5" => r <= X"56"; g <= X"ac"; b <= X"4d";
-		when X"6" => r <= X"2e"; g <= X"2c"; b <= X"9b";
-		when X"7" => r <= X"ed"; g <= X"f1"; b <= X"71";
-		when X"8" => r <= X"8e"; g <= X"50"; b <= X"29";
-		when X"9" => r <= X"55"; g <= X"38"; b <= X"00";
-		when X"A" => r <= X"c4"; g <= X"6c"; b <= X"71";
-		when X"B" => r <= X"4a"; g <= X"4a"; b <= X"4a";
-		when X"C" => r <= X"7b"; g <= X"7b"; b <= X"7b";
-		when X"D" => r <= X"a9"; g <= X"ff"; b <= X"9f";
-		when X"E" => r <= X"70"; g <= X"6d"; b <= X"eb";
-		when X"F" => r <= X"b2"; g <= X"b2"; b <= X"b2";
-		end case;
-	end process;
+		 when X"0" => r <= X"00"; g <= X"00"; b <= X"00";
+		 when X"1" => r <= X"FF"; g <= X"FF"; b <= X"FF";
+		 when X"2" => r <= X"96"; g <= X"28"; b <= X"2E";
+		 when X"3" => r <= X"5B"; g <= X"D6"; b <= X"CE";
+		 when X"4" => r <= X"9F"; g <= X"2D"; b <= X"AD";
+		 when X"5" => r <= X"41"; g <= X"B9"; b <= X"36";
+		 when X"6" => r <= X"27"; g <= X"24"; b <= X"C4";
+		 when X"7" => r <= X"EF"; g <= X"F3"; b <= X"47";
+		 when X"8" => r <= X"9F"; g <= X"48"; b <= X"15";
+		 when X"9" => r <= X"5E"; g <= X"35"; b <= X"00";
+		 when X"A" => r <= X"DA"; g <= X"5F"; b <= X"66";
+		 when X"B" => r <= X"47"; g <= X"47"; b <= X"47";
+		 when X"C" => r <= X"78"; g <= X"78"; b <= X"78";
+		 when X"D" => r <= X"91"; g <= X"FF"; b <= X"84";
+		 when X"E" => r <= X"68"; g <= X"64"; b <= X"FF";
+		 when X"F" => r <= X"AE"; g <= X"AE"; b <= X"AE";
+
+end case;
+end process;
 end Behavioral;

--- a/rtl/sid6581/wave_map.vhd
+++ b/rtl/sid6581/wave_map.vhd
@@ -124,6 +124,7 @@ begin
 		wave := (others => '0');
 		if enable_o1 = '1' then
 			case wave_sel1(2 downto 0) is
+				when "000" => wave := (others => '0');
 				when "001" => wave := triangle1;
 				when "010" => wave := sawtooth1;
 				when "011" => wave := st_out & x"0";
@@ -131,7 +132,6 @@ begin
 				when "101" => wave := (pt_out & x"0")  and pulse1;
 				when "110" => wave := (ps_out & x"0")  and pulse1;
 				when "111" => wave := (pst_out & x"0") and pulse1;
-				when others => null;
 			end case;
 			if wave_sel1(3) = '1' then
 				if wave_sel1(2 downto 0) = "000" then wave := x"fff"; end if;

--- a/rtl/sid6581/wave_map.vhd
+++ b/rtl/sid6581/wave_map.vhd
@@ -124,7 +124,6 @@ begin
 		wave := (others => '0');
 		if enable_o1 = '1' then
 			case wave_sel1(2 downto 0) is
-				when "000" => wave := (others => '0');
 				when "001" => wave := triangle1;
 				when "010" => wave := sawtooth1;
 				when "011" => wave := st_out & x"0";
@@ -132,6 +131,7 @@ begin
 				when "101" => wave := (pt_out & x"0")  and pulse1;
 				when "110" => wave := (ps_out & x"0")  and pulse1;
 				when "111" => wave := (pst_out & x"0") and pulse1;
+				when others => null;
 			end case;
 			if wave_sel1(3) = '1' then
 				if wave_sel1(2 downto 0) = "000" then wave := x"fff"; end if;

--- a/rtl/sid8580/sid_voice.v
+++ b/rtl/sid8580/sid_voice.v
@@ -117,7 +117,6 @@ assign acc_t  = {oscillator[23] ^ (ringmod_ctrl & ~osc_msb_in), oscillator[22:12
 // Waveform Output Selector
 always @(*) begin
 	case (control[6:4])
-		3'b000: wave_out = 0;
 		3'b001: wave_out = triangle;
 		3'b010: wave_out = sawtooth;
 		3'b011: wave_out = {_st_out, 4'b0000};


### PR DESCRIPTION
A known technique of creating digisamples on SID chips is to stop the square wave oscillator in the high state and modulate the result with the filter. By sending zeros in the voice, it cancels this effect.

You can see the difference in, for example, the last part of disc 2 in  [this demo](https://csdb.dk/release/?id=170950).