### PR TITLE
feat(): Allow for 1440p vertical crop

### DIFF
--- a/c64.sv
+++ b/c64.sv
@@ -1229,9 +1229,10 @@ always @(posedge CLK_VIDEO) begin
 		if(HDMI_HEIGHT == 1200) vcrop <= 240;
 	end
 	else if(HDMI_WIDTH >= 1440 && !scandoubler) begin
-		// 1920x1440 is a 4:3 resolution and won't fit in the previous if statement ( width > height * 1.5 )
-		// probably a 1536 option is good too, but i did not test it yet
-		if(HDMI_HEIGHT == 1440) begin vcrop <= 204; wide <= vcrop_en; end
+		// 1920x1440 and 2048x1536 are 4:3 resolutions and won't fit in the previous if statement ( width > height * 1.5 )
+		if(HDMI_HEIGHT == 1440) vcrop <= 240;
+		// 2 extra lines compared to 1080 cropping
+		if(HDMI_HEIGHT == 1536) vcrop <= 218;
 	end
 end
 

--- a/c64.sv
+++ b/c64.sv
@@ -1228,6 +1228,11 @@ always @(posedge CLK_VIDEO) begin
 		if(HDMI_HEIGHT == 1080) vcrop <= 10'd216;
 		if(HDMI_HEIGHT == 1200) vcrop <= 240;
 	end
+	else if(HDMI_WIDTH >= 1440 && !scandoubler) begin
+		// 1920x1440 is a 4:3 resolution and won't fit in the previous if statement ( width > height * 1.5 )
+		// probably a 1536 option is good too, but i did not test it yet
+		if(HDMI_HEIGHT == 1440) begin vcrop <= 204; wide <= vcrop_en; end
+	end
 end
 
 


### PR DESCRIPTION
This change allow for the vertical crop option to be enabled also on 1440p.
It give us a 1920x1440 nearly full screen C64 with just a couple of pix of border all around.
Not enabling vertical crop won't change much.

I have a 1536 screen with which i can make some tests later if this change is welcome.
