### PR TITLE
Magic Desk cartridge number of banks is not always a power of two

### DIFF
--- a/rtl/cartridge.v
+++ b/rtl/cartridge.v
@@ -466,7 +466,10 @@ always @(posedge clk32) begin
 				end
 
 				if(ioe_wr) begin
-					bank_lo <= data_in[6:0] & (bank_cnt - 1);
+					if(bank_cnt <= 16) bank_lo <= data_in[3:0];
+					else if(bank_cnt <= 32) bank_lo <= data_in[4:0];
+					else if(bank_cnt <= 64) bank_lo <= data_in[5:0];
+					else bank_lo <= data_in[6:0];
 					exrom_overide <= data_in[7];
 				end
 			end


### PR DESCRIPTION
In https://github.com/MiSTer-devel/C64_MiSTer/pull/124, Magic Desk cartridges up to maximum number of banks are supported. There are some cartridges in the wild though (such as Rogue 64) that don't have a power of two number of banks. Those carts should now be supported.