### PR TITLE
Zero Page address $01 bits 6 and 7: Wrong default value

### DIFF
--- a/rtl/cpu_6510.vhd
+++ b/rtl/cpu_6510.vhd
@@ -94,7 +94,7 @@ begin
 			if reset = '1' then
 				ioDir <= (others => '0');
 				ioData <= (others => '1');
-				currentIO <= (others => '1');
+				currentIO <= "00111111";  -- upper two bits are unused; ensure that the KERNAL is able to set Zero Page address $01 to $37 by default
 			end if;
 		end if;
 	end process;


### PR DESCRIPTION
If you enter `PRINT PEEK(1)` on real C64 hardware or on VICE right after boot-up then you will get `55` ($37) as a result. Also several online sources claim $37 as the correct default value. On MiSTer you get `247` ($F7), i.e. bits 6 and 7 are `1` instead of `0` after the KERNAL code (vanilla ROM) from $FDD5 to $FDDB has been executed.

My pull request suggests to fix this.

Disclaimer: Bits 6 and 7 of Zero Page address $01 are unused. So this is for sure not a big deal. I am not even sure if this fix here improves the compatibility for any game or demo. But I thought it might be interesting for accuracy and I am quite sure it is not having negative side effects.

P.S. Huge thank you @sorgelig and the whole MiSTer team for doing what you are doing. I am a contributor to the [MiSTer2MEGA65](https://github.com/sy2002/MiSTer2MEGA65) project which is a homage to your work.