### PR TITLE
Add rudimentary support for GMod2

### DIFF
--- a/rtl/cartridge.v
+++ b/rtl/cartridge.v
@@ -678,6 +678,20 @@ always @(posedge clk32) begin
 				end
 			end
 
+		// GMod2
+		60: begin
+				if(!init_n) begin
+					exrom_overide <= 0;
+					game_overide  <= 1;
+					bank_lo       <= 0;
+				end
+				else if(ioe_wr) begin
+					bank_lo       <= data_in[5:0];
+					exrom_overide <= data_in[6];
+				end
+			end
+
+
 		// GeoRAM
 		99: begin
 				IOE_ena    <= 1;


### PR DESCRIPTION
This PR adds support for CRT software cartridge type $3C = 60, which is the GMod2 type.

This fix is tested as part of the repo [https://github.com/MJoergen/C64MEGA65](https://github.com/MJoergen/C64MEGA65).

With this fix, the games "Muddy Racers" and "Wormhole" now work.

The commit only adds support for reading. The write support (to EEPROM and/or Flash) is not implemented.