### PR TITLE
Add support for Ocean type 2

### DIFF
--- a/rtl/cartridge.v
+++ b/rtl/cartridge.v
@@ -278,6 +278,13 @@ always @(posedge clk32) begin
 					bank_lo <= data_in[5:0];
 					bank_hi <= data_in[5:0];
 				end
+				// Autodetect Ocean Type B (512k)
+				// Only $8000 is used, while $A000 is RAM
+				if(cart_bank_wr) begin
+					if(cart_bank_num>=32) begin
+						game_overide <= 1;
+					end
+				end
 			end
 
 		// PowerPlay, FunPlay

--- a/rtl/cartridge.v
+++ b/rtl/cartridge.v
@@ -272,8 +272,10 @@ always @(posedge clk32) begin
 		// BANK is written to lower 6 bits of $DE00 - bit 8 is always set
 		// best to mirror banks at $8000 and $A000
 		5:	begin
-				exrom_overide <= 0;
-				game_overide  <= 0;
+				if(!init_n) begin
+					exrom_overide <= 0;
+					game_overide  <= 0;
+				end
 				if(ioe_wr) begin
 					bank_lo <= data_in[5:0];
 					bank_hi <= data_in[5:0];


### PR DESCRIPTION
This fix will auto-detect whether the Ocean cartridge is type 1 or type 2. The difference is the size of the cartridge, where 512k is type 2, smaller is type 1. And the effect is to switch to 8k mode in case of type 2.

Since the size itself is not readily available, this fix will auto-detect based on the number of banks. If 32 banks or more then this is a type 2 cartridge.

This is tested and verified on the C64MEGA65 repo.