### PR TITLE
Simple weak bits implementation

### DIFF
--- a/rtl/iec_drive/iec_drive.qip
+++ b/rtl/iec_drive/iec_drive.qip
@@ -15,3 +15,4 @@ set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) f
 set_global_assignment -name VHDL_FILE          [file join $::quartus(qip_path) iecdrv_via6522.vhd ]
 set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) iecdrv_mos8520.v   ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) iecdrv_misc.sv     ]
+set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) lfsr.v             ]

--- a/rtl/iec_drive/lfsr.v
+++ b/rtl/iec_drive/lfsr.v
@@ -1,0 +1,10 @@
+module random (
+   input clock,
+   output reg [30:0] lfsr
+);
+
+always @(posedge clock) begin
+  lfsr <= {lfsr[29:0], lfsr[30] ^~ lfsr[27]};
+end
+
+endmodule


### PR DESCRIPTION
This commit implements weak-bit/bad gcr behaviour of the 1541. Below are some examples of G64 images from the [C64_Preservation_Project_10th_Anniversary_Collection ](https://archive.org/details/C64_Preservation_Project_10th_Anniversary_Collection) that previously failed to load and now work with this pull request. Many more will now work, but many protections still do not (vmax2+, rapidlok, later vorpal). The changes should be relatively safe (only targets bad-gcr), but please doublecheck!

```
720_s1[mindscape_1988](!) (hangs at blue screen)
alternate_reality_the_city_s1[datasoft_1985] (hangs at blue screen)
barbarian_ii_s1[palace_1988](pal)(cyan2)(!) (resets c64)
bruce_lee[datasoft_1984](!) (hangs at blue screen after title picture)
circus_attractions_s1[rainbow_arts_1989](!) (exits after credits) 
combat_course[mindscape_1989] (hangs at blue screen, second protection after title pic)
gauntlet_ii[mindscape_1989](!) (hangs at blue screen)
grand_monster_slam_s1[rainbow_arts_1989](!) (exits to basic) 
hostage[mindscape_1989](!) (hangs at blue screen)
iron_lord_s1[ubisoft_1990](pal) (hang on blue screen after radwar protection screen)
logo[starbyte_1990](pal)(alt-weak) (hangs with stripe pattern)
mr_do[datasoft_1985](!) (hangs at blue screen)
myth_s1[system_3_1989](radwar)(pal)(!) (hangs at blue screen)
pole_position_ii[mindscape_1988](!) (hangs at blue screen)
road_raiders[mindscape_1988] (hangs at loading text)
rubicon_s1[21st_century_entertainment_1991](pal) (hangs at blue screen)
the_goonies[datasoft_1985](original_music)(!) (hangs at blue screen)
the_goonies[us_gold_1985](new_music)(!) (hangs at blue screen)
turrican_ii_s1[rainbow_arts_1991](!) (after loading, intro, and highscore table the graphics corrupts when starting a game)
western_games_s1[magic_bytes_1987](pal)(!) (hangs at inital loading)
x-out_s1[rainbow_arts_1989](!) (after title sequence stuck with asking for disk side a - should instead load shop)

b\barbarian_ii_s2[palace_1988](pal)(cyan2)(!).zip
a\action_fighter[firebird_1989](cyan2)(pal).zip
a\armageddon_man[martech_1987](cyan2)(pal).zip
t\terrys_big_adventure[shades_1989](cyan2)(pal).zip
t\tiger_road[capcom_1987](cyan2)(pal)(!).zip
t\trailblazer[gremlin_1986](cyan2)(pal).zip
s\shackled[us_gold_1988](cyan2)(pal).zip
s\solomons_key[us_gold_1987](poweplay)(cyan2)(pal)(!).zip
s\sidearms[capcom_1987](cyan2)(pal).zip
s\star_paws[software_projects_1987](cyan2)(pal).zip
s\street_fighter[capcom_1987](cyan2)(pal).zip
r\roadblasters[atari_1986](cyan2)(pal).zip
r\rolling_thunder[tengen_1989](pal)(cyan2).zip
o\octapolis[english_1984](cyan2)(pal).zip
n\night_raider[gremlin_1988](cyan2)(pal).zip
m\mega-apocalypse[martech_1987](cyan2)(pal).zip
i\implosion[cascade_1987](pal)(cyan2).zip
l\last_duel[capcom_1988](pal)(cyan2).zip
l\last_mission[data_east_1986](cyan2)(pal).zip
g\golden_axe_s1[probe_1989](cyan2)(pal)(alt).zip
g\gauntlet[us_gold_1986](cyan2).zip
g\golden_axe_s1[probe_1989](cyan2)(pal)(!).zip
g\golden_axe_s2[probe_1989](cyan2)(pal)(alt).zip
g\gauntlet[us_gold_1986](cyan2)(alt1).zip
g\gauntlet[us_gold_1986](cyan2)(alt2).zip
g\golden_axe_s2[probe_1989](cyan2)(pal)(!).zip
f\footballer_of_the_year_ii[gremlin_1989](cyan2)(!).zip
e\e-motion[us_gold_1990](cyan2)(pal).zip
d\dark_fusion[gremlin_1988](cyan2)(pal)(!).zip
d\dream_warrior[us_gold_1988](cyan2)(pal).zip
c\cosmic_causeway[gremlin_1987](cyan2)(pal).zip
c\chips_challenge[us_gold_1990](cyan2)(pal).zip
b\blues_brothers[titus_1991](cyan2)(pal).zip
```
