### PR TITLE
low level read logic from schematics and update via

### DIFF
--- a/rtl/iec_drive/c1541_direct_gcr.sv
+++ b/rtl/iec_drive/c1541_direct_gcr.sv
@@ -3,6 +3,12 @@
 // C1541 direct gcr module
 // (C) 2021 Alexey Melnikov
 //
+//
+// disk rotation and low level read logic based on schematics by Robin Wünderlich
+// TODO:
+// investigate potential T65 inaccurate so_n handling (e.g. not preventing
+// so_n sampling for upto 2 cycles into next instruction after an instruction
+// sets/clears overflow)
 //-------------------------------------------------------------------------------
 
 module c1541_direct_gcr
@@ -29,17 +35,15 @@ module c1541_direct_gcr
 	input        sd_buff_wr
 );
 
-assign sync_n      = ~mtr | busy | ~&shcur | ~mode;
-assign byte_n      = ~mtr | busy | ~&bit_cnt | bt_n[1];
 assign we          = buff_we;
-assign sd_buff_din = (sd_buff_addr >= track_len+2 ) ? 8'hFF : sd_buff_do;
-assign dout        = shcur[7:0];
+assign sd_buff_din = (sd_buff_addr >= track_len_adj + 2) ? 8'hFF : sd_buff_do;
+assign dout        = shreg[7:0];
 
-reg [13:0] track_len;
+reg [12:0] track_len, track_new, len_valid;
 always @(posedge sd_clk) if(sd_buff_wr && !sd_buff_addr[13:1]) begin
 	// size and possible flags
-	if(sd_buff_addr[0] == 0) track_len[7:0]  <= sd_buff_dout;
-	if(sd_buff_addr[0] == 1) track_len[13:8] <= sd_buff_dout[4:0];
+	if(sd_buff_addr[0] == 0) track_new[7:0]  <= sd_buff_dout;
+	if(sd_buff_addr[0] == 1) track_new[12:8] <= sd_buff_dout[4:0];
 end
 
 wire [7:0] sd_buff_do;
@@ -58,82 +62,189 @@ iecdrv_bitmem #(13) buffer
 	.q_b(buff_do)
 );
 
-reg [15:0] buff_addr;
-reg  [2:0] bit_cnt;
-wire       buff_do;
-reg  [7:0] buff_di;
-reg        buff_we;
-
-reg  [9:0] shreg;
-wire [9:0] shcur = {shreg[8:0], hf};
-reg  [1:0] bt_n;
+reg  [15:0] buff_addr;
+reg   [7:0] buff_di;
+wire        buff_do;
+reg         buff_we;
 
 wire [30:0] random_data;
-reg			hf; // data from head
-reg			ht; // data to head
-
 random lfsr(
    .clock(clk),
    .lfsr(random_data)
 );
 
+// 1541 part designations are based on the schematics in:
+// "Commodore 1541 Troubleshooting & Repair Guide – M. Peltier".
+// the UC1 chip integrates several discrete 1540 parts,
+// which are referenced by their 1540 designations
+assign sync_n = ~&shreg | ~mode;                                 // UC2  (UC1)
+assign byte_n = ~&UE3_bit_cnt | &shreg | UF4_enc_phase_cnt[1];   // UF3C (UC1) (soe in c1541_logic.sv)
+reg  [9:0] shreg;					 // UD2 74LS164, UE4A+UE4B 74LS74 (UC1)
+reg  [3:0] UF4_enc_phase_cnt;  // 74LS193 (UC1)
+reg  [3:0] UE6_enc_clk_cnt;    // 74LS193
+reg  [2:0] UE3_bit_cnt;        // 74LS191 (UC1)
+reg  [2:0] UD3_bit_cnt_w;      // 74LS165 (UC1)
+reg  [5:0] UD4A_cnt;           // 9602
+reg  [8:0] flux_cnt;
+reg        hf;                 // data from head
+reg        ht;                 // data to head
+
+// clks per bitcell in relation to track length:
+// = (CLK_FREQ / (8 * (BASE_RPM/60))) / track_len
+// -> BASE_ROT_TARGET = 400_000 (+/- wobble)
+localparam        BASE_RPM         =         300;
+localparam        CLK_FREQ         =  16_000_000;
+localparam        BASE_ROT_TARGET  =     400_000;
+localparam        WBL_FREQ 		  =          40; // WPM* 10
+localparam        WBL_MAX          =          20; // RPM*100
+localparam        WBL_CLKS_PER_STP = (((CLK_FREQ/(4*WBL_MAX_OFFSET)) * 600) / WBL_FREQ);
+localparam signed WBL_MAX_OFFSET   = ((BASE_ROT_TARGET/ 100) * WBL_MAX)/BASE_RPM;
+
+wire       [18:0] rot_target = 19'(BASE_ROT_TARGET) + wbl_offset;
+reg        [18:0] rot_clk_cnt;
+reg        [31:0] wbl_step_cnt;
+reg signed [9:0]  wbl_offset;
+reg               wbl_dir;
+
+// use len_valid as proxy for empty (half) tracks
+wire [12:0] track_new_adj = (track_new > 'd6000) ? track_new : len_valid;
+wire [12:0] track_len_adj = (track_len > 'd6000) ? track_len : len_valid;
+wire [13:0] recip = rec[track_len_adj-6000];
+
+// precalc reciprocals for track_len_adj = 6000 .. 8047
+reg  [13:0] rec[0:2047];
+initial begin
+    integer i;
+    for (i = 0; i < 2048; i = i + 1) begin
+        rec[i] = 14'((1 << 26) / (i + 6000));
+    end
+end
 
 always @(posedge clk) begin
-	reg [5:0] bit_clk_cnt;
-
 	buff_we <= 0;
 	
 	if(reset) begin
-		buff_addr   <= 16;
-		bit_clk_cnt <= 0;
-		bit_cnt     <= 0;
-		shreg       <= 0;
-		hf          <= 0;
-		ht          <= 0;
+		buff_addr           <= 16;
+		UE3_bit_cnt         <= 0;
+		UD3_bit_cnt_w 	     <= 0;
+		shreg               <= 0;
+		hf                  <= 0;
+		ht                  <= 0;
+		rot_clk_cnt         <= 0;
+		UF4_enc_phase_cnt   <= 0;
+		UE6_enc_clk_cnt     <= 0;
+		UD4A_cnt            <= 0;
+		flux_cnt            <= 9'd288;
+      wbl_offset          <= 0;
+      wbl_step_cnt        <= 0;
+      wbl_dir             <= 0;
+		track_len           <= 0;
+		len_valid           <= 'd7142;
 	end
-	else if(busy | ~mtr) begin
-		shreg       <= 0;
-		bit_cnt     <= 0;
-		bit_clk_cnt <= 0;
-		hf          <= 0;
-		ht          <= 0;
+	else if(busy) begin
 	end
 	else if(ce) begin
-		bt_n <= {bt_n[0],~&bit_cnt};
 
-		if(buff_addr[15:3] >= track_len +2) buff_addr <= 16;
-
-		if (bit_clk_cnt == 'b110000)
-		begin
-			buff_we	<= ~mode;
-			ht			<= buff_di[~bit_cnt];
-		end
-
-		if (bit_clk_cnt == 'b111100) begin
-			buff_addr   <= buff_addr + 1'd1;
-			if(buff_addr >= {track_len + 1'd1, 3'b111}) buff_addr <= 16;
-      end
-		
-		bit_clk_cnt <= bit_clk_cnt + 1'b1;
-		if (&bit_clk_cnt) begin
-			// induce a random flux reversal for weak-bits/bad-gcr read
-			// also simulate a random loss of framing by skipping a bit
-			if ((shcur[3:0] == 4'b0000) && (random_data[0]) && mode) begin
-				hf	<= 1;
-				if(random_data[14]) begin
-					buff_addr <= buff_addr + 1'd1;
-					if(buff_addr >= {track_len + 1'd1, 3'b111}) buff_addr <= 16;
+      // simulate independent rotation of disk (usually at 300RPM):
+      // let drive read logic self sync on the data,
+      // if writing, synchronize to encoder/decoder phase
+      if(mode) begin
+         if(rot_clk_cnt >= rot_target) begin
+            rot_clk_cnt <=  rot_clk_cnt - rot_target + track_len_adj;
+            if(track_new == track_len) begin
+               if(buff_addr >= {track_len_adj + 1'd1, 3'b111})
+						buff_addr <= 16'd16;
+					else begin
+						buff_addr <=  buff_addr + 1'd1;
+					end
 				end
-			end else
-				hf <= buff_do;
+			end else if(mtr)
+				rot_clk_cnt <= rot_clk_cnt + track_len_adj;
+				else rot_clk_cnt <= 0;
+		end else
+			if(&UE6_enc_clk_cnt && (UF4_enc_phase_cnt[1:0] == 2'b01)) begin
+				if(buff_addr >= {track_len + 1'd1, 3'b111}) buff_addr <= 16;
+				else buff_addr <=  buff_addr + 1'd1;
+			end
 
-			bit_clk_cnt <= {2'b00,freq,2'b00};
-			bit_cnt     <= bit_cnt + 1'b1;
-			shreg       <= shcur;
+		// drivers of hf (flux reversals from data, or random flux reversals)
+      if(!mode) 								  hf <= 0;
+		else if(!flux_cnt)                 hf <= 1;
+		else if(busy)         	           hf <= 0;
+		else if(track_len <= 6000)         hf <= 0;
+		else if(rot_clk_cnt >= rot_target) hf <= buff_do;
+		else                               hf <= 0;  // demux dogma
 
-			if(~sync_n) bit_cnt <= 0;
-			if(bit_cnt == 7) buff_di <= din;
+		// random flux reversal counters (weak bits/bad gcr)
+		if(hf) begin
+         if(!flux_cnt)  flux_cnt <= random_data[7:0] + 9'd37;
+         else           flux_cnt <= random_data[4:0] + 9'd288;
+      end
+      else if(flux_cnt) flux_cnt <= flux_cnt - 1'b1;
+
+		// encoder-decoder clock divider based on freq
+		if(&UE6_enc_clk_cnt) begin
+			UE6_enc_clk_cnt <= {2'b00,freq};
+		end else
+		   UE6_enc_clk_cnt <= UE6_enc_clk_cnt + 1'b1;
+		
+		// encoder-decoder
+		// flux reversals reset (see filter stage below) UE6 and UF4 counters
+		// a one bit will be clocked into the shift register in phase b0010.
+		// if the allowed time window expires without a flux reversal 0 bits
+		// will be clocked into the shift register (phases b0110, b1010 etc.)
+		if(&UE6_enc_clk_cnt) begin
+         UF4_enc_phase_cnt <= UF4_enc_phase_cnt + 1'b1;
+		   // transition into phase bxx10
+         if(UF4_enc_phase_cnt[1:0] == 2'b01) begin
+            shreg          <= {shreg[8:0], ~|UF4_enc_phase_cnt[3:2]}; // UE5a (UC1)
+            UE3_bit_cnt    <= UE3_bit_cnt   + 1'b1;
+            UD3_bit_cnt_w  <= UD3_bit_cnt_w + 1'b1;
+         end
+         // transition into phase bxx11
+         else if((UF4_enc_phase_cnt[1:0] == 2'b10) && (&UE3_bit_cnt)) begin
+           buff_di        <= din;
+           UD3_bit_cnt_w  <= 0;
+         end
+         // transition into phase bxx00 (writing)
+         else if((UF4_enc_phase_cnt[1:0] == 2'b11)) begin
+            if(!mode) begin
+               ht      <= buff_di[~UD3_bit_cnt_w];
+				   buff_we <= ~mode;
+				end
+			end
 		end
+
+      // detected flux reversals are validated by a filter stage
+      // as we only model valid flux reversals the effect is a
+      // 2.5us delay (40clks = 64-24) of the UE6/UF4 counter reset
+		if (UD4A_cnt) begin
+		   UD4A_cnt <= UD4A_cnt + 1'b1;
+			if (&UD4A_cnt) begin
+				UE6_enc_clk_cnt   <= {2'b00,freq};
+				UF4_enc_phase_cnt <= 0;
+			end
+		end else if(hf) UD4A_cnt <= 6'd24;
+
+		if(~sync_n) UE3_bit_cnt <= 0;
+
+		// drive wobble
+      if(wbl_step_cnt >= WBL_CLKS_PER_STP) begin
+         wbl_step_cnt <= 0;
+         wbl_dir      <= (rot_target > (BASE_ROT_TARGET + WBL_MAX_OFFSET)) ? 1'b0 :
+                         (rot_target < (BASE_ROT_TARGET - WBL_MAX_OFFSET)) ? 1'b1 :
+                         wbl_dir;
+         wbl_offset   <= wbl_offset + (wbl_dir ? 10'sd1 : -10'sd1);
+      end else
+         wbl_step_cnt <= wbl_step_cnt + 1'b1;
+
+      // adjustment for disk geometry if head moves to new track
+      // use valid length of neighbouring track as proxy for empty track
+      track_len <= track_new;
+      if(track_new != track_len) begin
+         if(track_new > 'd6000) len_valid <= track_new;
+         buff_addr <= 16'(((43'h0 + ((buff_addr - 16) * track_new_adj)) * recip) >> 26) + 16'd16;
+      end
 	end
 end
 


### PR DESCRIPTION
The new read logic is more accurate to original hardware and allows a larger number of (protected) g64 images to work (see list below for a few examples). "iecdrv_via6522.vhd" was also updated to the latest version. There are a  couple of issues, where I need some help (@sorgelig): 

1) Quartus shows these warnings, because of my reciprocal (rom) table:
Warning (10030): Net "rec.data_a" at c1541_direct_gcr.sv(115) has no driver or initial value, using a default initial value '0'
Warning (10030): Net "rec.waddr_a" at c1541_direct_gcr.sv(115) has no driver or initial value, using a default initial value '0'
Warning (10030): Net "rec.we_a" at c1541_direct_gcr.sv(115) has no driver or initial value, using a default initial value '0'

I researched these and they are supposed to be completely fine  and harmless. But, I don't know what the current policy on these kind of warnings in the Mister Project is. If problematic we could get rid of them by instantiating an equivalent rom/lut - but I am not quite sure what the correct one would be? Quartus figured it out automatically and it's working fine (no latency), but it's hard to tell (for me) what it actually inferred. I can easily provide the mif file as quartus produces it as an intermediate file when compiling.

2) The new code works fine as is and many more images work, but even more images would work if the support code would deliver track data faster. 

Currently it seems it takes the support code roughly 2.15ms to  load  data for a track and pump it through to the FPGA side - correct me if this is wrong, I measured it with the 1541 drive timer. For the usual two half track steps it's a total of approx. 4.3ms, which is just outside the window needed for some of the tighter protections.
EDIT - ADDITIONAL INFO: If loaded from within a zip file, the time I measured is upto 9ms. This makes loading some titles work outside a zip and not within a zip (e.g. destiny loads unreliably within a zip, but works consistent outside a zip, arkanoid (vmax3) works outside a zip but not within). 

Potential solutions:
a)  The best solution would be to load the complete disk (g64 images are very small < 400kb) to any sort of ram (latency does not matter here). Saving tracks could stay the same as usually the  write code it not very picky or time critical. No need to save the whole disk when entering or leaving the menu, it could still save individual tracks in real time. Maybe @sorgelig can help here?
b) Stop the drive CPU, VIAs and drive logic. I tried this (simple && !busy for the clks and phi_r, phi_f inputs), and it works! Even fast loaders (and dolphin, speedos, jiffy, heureka etc.) work. But I do not like it so much, as the c64 could still measure the time the 1541 takes for certain operations (found no software doing this, but it's a potential). Even though I found no side effects does not mean there aren't any.

3) T65 core's so handling might be inaccurate. Various sources (VICE authors, Denise authors) state that some instructions  clearing/setting overflow prevent sampling/using of external so_n for a number of cycles well into the next instruction. Also a real 6502 samples so_n at 400ns (roughly at phi2_r) into an instruction cycle. I tested replicating the latter by gating so_n for the cpu by phi2_r, but as it did not make a difference for the titles I tested I left it out of this pull request. The other effects seem to be real though., so that's something for future investigations.

That's it in a nutshell, have fun with this! 

Protected images now working from [C64_Preservation_Project_10th_Anniversary_Collection](https://archive.org/details/C64_Preservation_Project_10th_Anniversary_Collection):
```
\0\4th_and_inches[accolade_1987](ntsc)(!).zip
\0\1942[capcom_1986](rl).zip
\a\ace_of_aces[accolade_1986](ntsc)(rl5).zip
\a\acrojet[microprose_1986](rl2)(pal).zip
\a\alcon[taito_1988](vmax3)(!).zip
\a\apollo_18_s1[accolade_1987](rl-unknown)(ntsc).zip
\b\blue_angels[accolade_1989](ntsc)(rl7)(alt1).zip
\b\bubble_bobble[taito_1988](vmax3)(!).zip
\c\card_sharks[accolade_1987](rl6)(pal).zip
\c\card_sharks[accolade_1987](rl6)(ntsc).zip
\c\conflict_in_vietnam[microprose_1986](rl2).zip
\d\deceptor[avantage_1986](rl5)(ntsc).zip
\f\fast_break[accolade_1988](rl7)(ntsc).zip
\f\fight_night[accolade_1985](rl1)(ntsc).zip
\g\ghosts_and_goblins[elite_1986](rl6)(ntsc).zip
\g\gunship_s2[microprose_1985](rl5)(ntsc)(alt2).zip
\h\hardball[accolade_1987](ntsc)(04)(rl5).zip
\m\mars_saga_s1[ea_1988](!).zip
\p\pirates_s1[microprose_1987](rl6)(ntsc).zip
\p\plasmatron[avantage_1987](ntsc)(rlok).zip
\p\power[avantage_1987](ntsc)(rl6).zip
\p\power_boat_usa[accolade_1989](rl7)(pal).zip
\p\power_drift[activision_1989](rl7).zip
\t\times_of_lore[origin_1988](vmax3)(!).zip
\t\top_fuel_eliminator[activision_1987](vmax2)(!).zip
\t\turrican_s1[rainbow_arts_1990](pal)(!).zip
\t\tv_sports_football_s1[cinemaware_1989](vmax4).zip
\s\spy_vs_spy_i_and_ii[avantage_1984](ntsc)(rl6).zip
\s\super_pac-man[thunder_mtn_1988](vmax3)(!).zip
\x\xevious[mindscape_1987](vmax2)(!).zip
```