### PR TITLE
Add OSD option for REU 512K wrap and mask bank register correctly

### DIFF
--- a/c64.sv
+++ b/c64.sv
@@ -244,7 +244,8 @@ localparam CONF_STR = {
 
 	"P2,Hardware;", 
 	"P2O[52],GeoRAM,Disabled,4MB;",
-	"P2O[54:53],REU,Disabled,512KB,2MB (512KB wrap),16MB;",
+	"P2O[54:53],REU,Disabled,512KB,2MB,16MB;",
+	"hCP2O[63],REU wrap,512KB,None;",
 	"P2-;",
 	"P2O[25],External IEC,Disabled,Enabled;",
 	"P2O[43],Expansion,Joysticks,RS232;",
@@ -464,7 +465,7 @@ hps_io #(.CONF_STR(CONF_STR), .VDNUM(2), .BLKSZ(1)) hps_io
 	.paddle_3(pd4),
 
 	.status(status),
-	.status_menumask({ezfl_mod || ezfl_save_en, cart_ezfl, ~status[69], ~status[66], status[58], |status[47:46], status[16], status[13], tap_loaded, 1'b0, |vcrop, status[56]}),
+	.status_menumask({status[54], ezfl_mod || ezfl_save_en, cart_ezfl, ~status[69], ~status[66], status[58], |status[47:46], status[16], status[13], tap_loaded, 1'b0, |vcrop, status[56]}),
 	.buttons(buttons),
 	.forced_scandoubler(forced_scandoubler),
 	.gamma_bus(gamma_bus),
@@ -606,12 +607,14 @@ wire        reu_irq;
 
 wire        reu_oe  = IOF && reu_cfg;
 wire  [1:0] reu_cfg = status[54:53];
+wire        reu_wrap = ~status[63] & status[54];
 
 reu reu
 (
 	.clk(clk_sys),
 	.reset(~reset_n),
 	.cfg(reu_cfg),
+	.wrap(reu_wrap),
 
 	.dma_req(dma_req),
 

--- a/rtl/reu.v
+++ b/rtl/reu.v
@@ -7,7 +7,8 @@ module reu
 (
 	input             clk,
 	input             reset,
-	input       [1:0] cfg, //none, 512K, 2MB (512KB wrap), 16MB
+	input       [1:0] cfg,  // none, 512K, 2MB, 16MB
+	input             wrap, // 0: no wrap, 1: 512KB wrap
 
 	output reg        dma_req,
 
@@ -119,7 +120,7 @@ always @(posedge clk) begin
 					 3: cpu_din <= addr_c64[15:8];
 					 4: cpu_din <= addr_ram[7:0];
 					 5: cpu_din <= addr_ram[15:8];
-					 6: cpu_din <= addr_ram[23:16] | ~addr_mask[23:16];
+					 6: cpu_din <= addr_ram[23:16] | (wrap ? 8'hF8 : ~addr_mask[23:16]);
 					 7: cpu_din <= length[7:0];
 					 8: cpu_din <= length[15:8];
 					 9: cpu_din <= {intr[7:5],5'h1F};
@@ -150,7 +151,7 @@ always @(posedge clk) begin
 					cnt <= 0;
 					if(op_act[1]) begin
 						if(~ctl[7]) addr_c64 <= addr_c64 + 1'd1;
-						if(~ctl[6]) addr_ram <= (cfg == 2) ? {addr_ram[20:19], addr_ram[18:0] + 1'd1} : ((addr_ram + 1'd1) & addr_mask);
+						if(~ctl[6]) addr_ram <= (wrap ? {addr_ram[23:19], addr_ram[18:0] + 1'd1} : (addr_ram + 1'd1)) & addr_mask;
 						stage <= 0;
 						if(length == 1 || error) begin
 							if(cmd[5]) begin


### PR DESCRIPTION
This pull request implements the new OSD option to enable/disable 512K wrapping in REU and correct read back of the bank register as discussed in #203 and MiSTer-devel/C128_MiSTer#46