### PR TITLE
Full DDRAM Image Loading, DMA Engine & Drive OSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Based on FPGA64 by Peter Wendrich with heavy later modifications by different pe
 - Special reduced border mode for 16:9 display
 - C128/Smart Turbo mode up to 4x
 - Real-time clock
+- Drive OSD showing mount status, read/write activity and current track
 
 ## Installation
 Copy the *.rbf to the root of the SD card. Copy disks/carts to C64 folder.
@@ -68,17 +69,25 @@ To use JiffyDOS or another alternative kernel, replace the filenames with the na
 
 To confirm you have the correct image, the BOOT.ROM created must be exactly 32768 or 49152 (in case of 32KB C1541 ROM) bytes long. 
 
-Two loadable ROM sets are provided: **DolphinDOS v2.0** and **SpeedDOS v2.7**. Both ROMs support parallel Disk Port. DolphinDOS is the faster of the two.
+Two loadable ROM sets are provided: **DolphinDOS v2.0** and **SpeedDOS v2.7**. Both ROMs support the parallel Disk Port (more info below). DolphinDOS is the faster of the two.
 
 For **C1581** you can use separate ROM with size up to 32768 bytes.
 
 ### Autoload the cartridge
 In OSD->Hardware page you can choose Boot Cartridge, so every time a core is loaded, this cartridge will be loaded too.
 
-### Parallel port for disks.
+### Parallel port
 Are you tired of long loading times and fast loaders aren't really fast when comparing to other systems? 
-In OSD->System choose **Expansion: Fast Disks**. Then load [DolphinDOS_2.0.rom](releases/DolphinDOS_2.0.rom). You will get about **20x times faster** loading from disks!
 
+In OSD->Hardware set **System ROM: Loadable**. Then load the provided [DolphinDOS_2.0.rom](releases/DolphinDOS_2.0.rom) via OSD->Hardware->**System ROM: C64+C1541**. Also make sure that OSD-Drives->**Parallel Port: Enabled**. You will get about **20x times faster** loading from disks!
+
+The C64 User Port is a historical bottleneck because the Parallel Disk cable, RS232 modems, and 4-Player Joystick adapters all require exclusive access to it. The MiSTer tries to be smart about this:
+* If the core detects activity on the disk serial lines, it assumes a fast loader is engaging and instantly grants the User Port to the Parallel Disk drive.
+* Once disk activity stops for exactly 0.5 seconds, the User Port is automatically handed back to the RS232 module or the 4-Player Joystick adapter. 
+
+Caution: The parallel port for disk drives is only enabled if you load a C64+Drive ROM where the Drive ROM portion is exactly **32KB** (like with the provided Dolphin DOS or Speed DOS). The standard kernal and e.g. JiffyDOS do not have special Drive ROMs (16KB), and thus the parallel port will be disabled (regardless of setting in drives).
+
+JiffyDOS is a fast-serial replacement for standard kernal and achieves fast loading without the parallel port.
 ### Turbo modes
 
 **C128 mode:** this is C128 compatible turbo mode available in C64 mode on Commodore 128 and can be controlled from software, so games written with this turbo mode support will take advantage of this.
@@ -121,4 +130,22 @@ To get real time in GEOS, copy CP-CLOCK64-1.3 from supplied [disk](https://githu
 
 ### 1541 Drive
 
-C1541 implementation supports D64, T64, G64 and G81 images. Use supplied empty disks for saving or copying to. Images mounted from inside zip files are read only. You can force mounting an image (outside of zip) write protected through the menu or by changing the file attribute. The 1541 simulation for G64 images has (limited) support for protected disks. For best results try on original kernal, try PAL and NTSC (reset after changing!), try alternate images (alts), try multiple times (some protections are unreliable even on original hardware), be patient (some titles take very long to load), try with write protect on and off. If all else fails you can try the drive speed and drive wobble settings. Protected disk in some cases won't work yet and still require further tuning of access times.
+The C64 core supports both C1541 and C1581 drives with D64, T64, G64 and D81 disk images. Up to two drives #8 and #9 can be enabled and used simultaneously. A simulated C1541 drive is auto-enabled for D64, T64 and G64 images, while the C1581 is enabled for D81 images.
+
+Advanced C1541 features:
+* Accurate low-level read logic based on original schematics
+* Physical disk rotation simulation
+* AGC flux events (weak bits)
+* Drive Overlay: an optional OSD showing current track and read/write activity
+
+Images mounted from inside zip files are strictly read only. For regular files, you can force write protection via the menu or by changing the file's read-only attribute. Caution: Changing the write-protect option for a drive only takes effect the next time you mount an image. Use the supplied empty disks for saving or copying to. Saving to a mounted (and writeable) image is done seamlessly in the background, there is no need to open the F12 Menu to force a save. You can monitor drive activity directly on-screen for both disk drives. The available modes are configurable via the drives menu: **Activity Only** (pops up only on activity), **If Mounted** (always visible if a disk is inserted),  and **Off**. The overlay shows the current track number and uses color coding to indicate reads (yellow), writes (red) and no activity (green).
+
+The G64 format can accurately represent over 90% of original copy-protected software. However, getting protected software to load can sometimes be tricky. Always mount write protected, as some devious protections try to format your disk if they detect a copy and others even require being write protected to load. If a game fails to load, try the following steps:
+* Use the standard C64 kernal (disable fast loaders).
+* Toggle between PAL and NTSC modes via menu.
+* Try alternate dumps of the disk (alts).
+* Be patient! Some titles take a very long time to load.
+* Try multiple times (some protections are unreliable even on original hardware).
+* If all else fails, experiment with the drive speed and drive wobble settings.
+
+Note: In some cases protected disk will not work yet, or fall outside the scope of what the G64 format can accurately capture.

--- a/c64.sv
+++ b/c64.sv
@@ -180,13 +180,27 @@ module emu
 	input         OSD_STATUS
 );
 
-assign {DDRAM_CLK, DDRAM_BURSTCNT, DDRAM_ADDR, DDRAM_DIN, DDRAM_BE, DDRAM_RD, DDRAM_WE} = 0;
+wire [7:0]  drv_ddram_burstcnt;
+wire [28:0] drv_ddram_addr;
+wire        drv_ddram_rd;
+wire        drv_ddram_we;
+wire [63:0] drv_ddram_din;
+wire [7:0]  drv_ddram_be;
+
+assign DDRAM_CLK      = clk_sys;
+assign DDRAM_BURSTCNT = drv_ddram_burstcnt;
+assign DDRAM_ADDR     = drv_ddram_addr;
+assign DDRAM_RD       = drv_ddram_rd;
+assign DDRAM_WE       = drv_ddram_we;
+assign DDRAM_DIN      = drv_ddram_din;
+assign DDRAM_BE       = drv_ddram_be;
 assign {SD_SCK, SD_MOSI, SD_CS} = 'Z;
 
 assign LED_DISK   = 0;
 assign LED_POWER  = 0;
 assign LED_USER   = |drive_led | ioctl_download | ioctl_upload | ezfl_mod | tape_led | ~disk_ready;
-assign BUTTONS    = 0;
+reg    close_osd  = 0;
+assign BUTTONS    = {1'b0, close_osd};
 assign VGA_DISABLE = 0;
 assign VGA_SCALER = 0;
 assign HDMI_BLACKOUT = 0;
@@ -276,8 +290,9 @@ localparam CONF_STR = {
 	"P3O[58:57],Enable Drive #8,If Mounted,Always,Never;",
 	"P3O[56:55],Enable Drive #9,If Mounted,Always,Never;",
 	"P3O[44],Parallel port,Enabled,Disabled;",
+	"P3O[86:85],Drives OSD,Activity Only,If Mounted,Debug,Off;",
 	"P3-;",
-	"P3O[80:78],Drive RPM    (G64),300,301,302,305,310,295,298,299;",
+	"P3O[80:78],Drive RPM    (G64),300.0,300.1,300.5,301.0,302.0,299.0,299.5,299.9;",
 	"P3O[81],Drive Wobble (G64),Off,On;",
 	"P3-;",
 	"P3R[6],Reset Disk Drives;",
@@ -333,18 +348,38 @@ pll_cfg pll_cfg
 	.reconfig_from_pll(reconfig_from_pll)
 );
 
+reg ntsc_r = 0;
 always @(posedge CLK_50M) begin
 	reg ntscd = 0, ntscd2 = 0;
 	reg [2:0] state = 0;
-	reg ntsc_r;
+	reg [23:0] delay = 0;
+	reg osd_s1 = 0, osd_s2 = 0;
 
-	ntscd <= ntsc;
+	osd_s1 <= OSD_STATUS;
+	osd_s2 <= osd_s1;
+
+	// bringing ntsc_req into the CLK_50M domain
+	ntscd  <= ntsc_req;
 	ntscd2 <= ntscd;
 
 	cfg_write <= 0;
-	if(ntscd2 == ntscd && ntscd2 != ntsc_r) begin
-		state <= 1;
-		ntsc_r <= ntscd2;
+	close_osd <= 0;
+
+	if(ntscd2 != ntsc_r) begin
+	if(osd_s2 && delay < 24'd2500000) begin // 50ms pulse to close OSD
+	// Close OSD so that PAL/NTSC switch induced reset does not
+	// blank screen, if PAUSE when in OSD is enabled
+			close_osd <= 1;
+			delay <= delay + 1'd1;
+			end else if (delay < 24'd7500000) begin // 150ms total delay
+			delay <= delay + 1'd1;
+			end else begin
+			state <= 1;
+			ntsc_r <= ntscd2;
+			delay <= 0;
+			end
+	end else begin
+	delay <= 0;
 	end
 
 	if(!cfg_waitrequest) begin
@@ -376,17 +411,26 @@ always @(posedge CLK_50M) begin
 	end
 end
 
+reg ntsc_sys1 = 0, ntsc = 0;
 reg reset_n;
 reg reset_wait = 0;
+reg ntsc_prev = 0;
+
 always @(posedge clk_sys) begin
 	integer reset_counter;
 	reg old_download;
 	reg do_erase = 1;
 
+	// Bringing ntsc_r back into clk_sys domain
+	ntsc_sys1 <= ntsc_r;
+	ntsc <= ntsc_sys1;
+	// Detect pal/ntsc switch
+	ntsc_prev <= ntsc;
+
 	reset_n <= !reset_counter;
 	old_download <= ioctl_download;
 
-	if (RESET | status[0] | status[17] | buttons[1] | !pll_locked) begin
+	if (RESET | status[0] | status[17] | buttons[1] | !pll_locked | (ntsc_prev != ntsc)) begin
 		if(RESET) do_erase <= 1;
 		reset_counter <= 100000;
 	end
@@ -465,8 +509,7 @@ hps_io #(.CONF_STR(CONF_STR), .VDNUM(2), .BLKSZ(1)) hps_io
 	.paddle_3(pd4),
 
 	.status(status),
-	.status_menumask({status[54], ezfl_mod || ezfl_save_en, cart_ezfl, ~status[69], ~status[66], status[58], |status[47:46], status[16], status[13], tap_loaded, 1'b0, |vcrop, status[56]}),
-	.buttons(buttons),
+	.status_menumask({status[54], ezfl_mod || ezfl_save_en, cart_ezfl, ~status[69], ~status[66], status[58], |status[47:46], status[16], status[13], tap_loaded, 1'b0, |vcrop, status[56]}), .buttons(buttons),
 	.forced_scandoubler(forced_scandoubler),
 	.gamma_bus(gamma_bus),
 
@@ -1000,7 +1043,7 @@ wire        UMAXromH;
 wire [17:0] audio_l,audio_r;
 wire  [7:0] r,g,b;
 
-wire        ntsc = status[2];
+wire        ntsc_req = status[2];
 
 fpga64_sid_iec fpga64
 (
@@ -1148,6 +1191,8 @@ wire       drive_iec_data_o;
 wire       drive_reset = ~reset_n | status[6] | (load_c1581 & ioctl_download);
 
 wire [1:0] drive_led;
+wire [6:0] drive_track[2];
+wire [1:0] drive_we;
 wire       disk_ready;
 
 reg [1:0] drive_mounted = 0;
@@ -1187,6 +1232,8 @@ iec_drive iec_drive
 	.drive_wobble(status[81]),
 
 	.led(drive_led),
+	.out_track(drive_track),
+	.out_we(drive_we),
 	.disk_ready(disk_ready),
 
 	.par_data_i(drive_par_i),
@@ -1209,8 +1256,18 @@ iec_drive iec_drive
 	.rom_addr(load_rom ? (ioctl_addr[15:0] - 16'h4000) : {1'b1,ioctl_addr[14:0]}),
 	.rom_data(ioctl_data),
 	.rom_wr(((load_rom && ioctl_addr[16:14]) || load_c1581) && ioctl_download && ioctl_wr),
-	.rom_std(status[14])
-);
+	.rom_std(status[14]),
+
+	.DDRAM_BUSY(DDRAM_BUSY),
+	.DDRAM_BURSTCNT(drv_ddram_burstcnt),
+	.DDRAM_ADDR(drv_ddram_addr),
+	.DDRAM_DOUT(DDRAM_DOUT),
+	.DDRAM_DOUT_READY(DDRAM_DOUT_READY),
+	.DDRAM_RD(drv_ddram_rd),
+	.DDRAM_WE(drv_ddram_we),
+	.DDRAM_DIN(drv_ddram_din),
+	.DDRAM_BE(drv_ddram_be)
+	);
 
 reg drive_ce;
 always @(posedge clk_sys) begin
@@ -1354,6 +1411,172 @@ end
 
 assign HDMI_FREEZE = freeze;
 
+// Snoop DDRAM reads and writes for debug overlay
+reg [63:0] dbg_ddram_data = 0;
+reg [31:0] dbg_ddram_addr = 0;
+reg [31:0] dbg_out_addr   = 0;
+reg        dbg_wait_data  = 0;
+reg        dbg_valid      = 0;
+reg  [7:0] dbg_burst_cnt  = 0;
+
+reg [63:0] dbg_wr_data    = 0;
+reg [31:0] dbg_wr_addr    = 0;
+reg        dbg_wr_valid   = 0;
+
+always @(posedge clk_sys) begin
+    reg old_rd, old_we;
+
+    old_rd <= drv_ddram_rd;
+    old_we <= drv_ddram_we;
+
+    dbg_valid <= 0;
+    if (~old_rd & drv_ddram_rd) begin
+		dbg_ddram_addr <= {3'b0, drv_ddram_addr};
+        dbg_burst_cnt <= drv_ddram_burstcnt;
+        dbg_wait_data <= 1;
+		end
+
+		if (DDRAM_DOUT_READY && dbg_wait_data) begin
+			dbg_ddram_data <= DDRAM_DOUT;
+			dbg_out_addr   <= dbg_ddram_addr;
+			dbg_valid      <= 1;
+
+			if (dbg_burst_cnt <= 8'd1) begin
+				dbg_wait_data  <= 0;
+			end else begin
+				dbg_burst_cnt  <= dbg_burst_cnt - 8'd1;
+				dbg_ddram_addr <= dbg_ddram_addr + 1'd1;
+			end
+		end
+
+    dbg_wr_valid <= 0;
+    if (~old_we & drv_ddram_we) begin
+		dbg_wr_addr <= {3'b0, drv_ddram_addr};
+        dbg_wr_data <= drv_ddram_din;
+        dbg_wr_valid <= 1;
+	end
+end
+
+// Allow cursor keys to change debug base addr for overlay
+// addr stepsize h008 for cursor up & down
+// addr stepsize h100 for cursor left & right
+// timed autorepeat and debounce
+
+reg [31:0] dbg_base_addr = 32'h06000000;
+reg old_ps2_stb;
+reg [23:0] repeat_timer;
+reg repeat_active;
+reg dir_up;
+reg dir_down;
+reg dir_left;
+reg dir_right;
+
+always @(posedge clk_sys) begin
+    old_ps2_stb <= ps2_key[10];
+
+    if (old_ps2_stb != ps2_key[10]) begin
+        if (ps2_key[9]) begin
+            if (ps2_key[8] && ps2_key[7:0] == 8'h75) begin // Up Arrow
+                dbg_base_addr <= dbg_base_addr - 8;
+                dir_up <= 1; dir_down <= 0; dir_left <= 0; dir_right <= 0;
+                repeat_timer <= 24'd15000000; // ~0.3s delay
+                repeat_active <= 1;
+            end else if (ps2_key[8] && ps2_key[7:0] == 8'h72) begin // Down Arrow
+                dbg_base_addr <= dbg_base_addr + 8;
+                dir_up <= 0; dir_down <= 1; dir_left <= 0; dir_right <= 0;
+                repeat_timer <= 24'd15000000;
+                repeat_active <= 1;
+            end else if (ps2_key[8] && ps2_key[7:0] == 8'h6B) begin // Left Arrow
+                dbg_base_addr <= dbg_base_addr - 32'h100;
+                dir_up <= 0; dir_down <= 0; dir_left <= 1; dir_right <= 0;
+                repeat_timer <= 24'd15000000;
+                repeat_active <= 1;
+            end else if (ps2_key[8] && ps2_key[7:0] == 8'h74) begin // Right Arrow
+                dbg_base_addr <= dbg_base_addr + 32'h100;
+                dir_up <= 0; dir_down <= 0; dir_left <= 0; dir_right <= 1;
+                repeat_timer <= 24'd15000000;
+                repeat_active <= 1;
+            end else begin
+                repeat_active <= 0;
+            end
+        end else begin
+            if ((ps2_key[8] && ps2_key[7:0] == 8'h75 && dir_up) ||
+                (ps2_key[8] && ps2_key[7:0] == 8'h72 && dir_down) ||
+                (ps2_key[8] && ps2_key[7:0] == 8'h6B && dir_left) ||
+                (ps2_key[8] && ps2_key[7:0] == 8'h74 && dir_right)) begin
+                repeat_active <= 0;
+                dir_up <= 0;
+                dir_down <= 0;
+                dir_left <= 0;
+                dir_right <= 0;
+            end
+        end
+    end else if (repeat_active) begin
+        if (repeat_timer == 0) begin
+            if (dir_up) dbg_base_addr <= dbg_base_addr - 8;
+            if (dir_down) dbg_base_addr <= dbg_base_addr + 8;
+            if (dir_left) dbg_base_addr <= dbg_base_addr - 32'h100;
+            if (dir_right) dbg_base_addr <= dbg_base_addr + 32'h100;
+            repeat_timer <= 24'd2000000; // ~0.04s repeat
+        end else begin
+            repeat_timer <= repeat_timer - 1'd1;
+        end
+    end
+end
+
+// Drive Overlay display:
+//  - three modes: on activity (default), if enabled, debug and off
+//  - color coded: green for idle (only shows in "if enabled" and "debug" mode)
+//                 yellow for (read) activity (via drive led)
+//                 red for write activity (covers writes to disk & flushing to sd)
+//  - track number: Full tracks and half tracks (e.g. 33.5)
+//  - drive number: (#8, #9)
+//  - auto adjusts for pal/ntsc
+//
+// debug mode captures DDRAM reads/writes:
+//  - reads displayed on the left (green), writes on the right (yellow)
+//  - rolling buffer (top 8 lines) shows the last 8 reads/writes and addresses
+//  - base address captures (botoom 8 lines) shows 8 read/writes starting at base address
+//  - base address can be changed in real time with cursor keys (left, right, up, down)
+//  - captures live read/writes not memory content, so set address before you expect read/writes (!)
+//
+//
+wire [1:0] ovl_color;
+
+reg [1:0] ce_sys_div = 0;
+wire ce_sys = (ce_sys_div == 0);
+always @(posedge clk_sys) ce_sys_div <= ce_sys_div + 1'd1;
+
+drv_overlay drv_ovl (
+	.clk(clk_sys),
+	.ce(ce_sys),
+	.hblank(hblank),
+	.vblank(vblank),
+
+	.drive_osd_mode(status[86:85]),
+	.ntsc(ntsc),
+	.drive_led(drive_led),
+	.drive_mounted(drive_mounted),
+	.drive_track_0(drive_track[0]),
+	.drive_track_1(drive_track[1]),
+	.drive_we(drive_we),
+
+	.valid(dbg_valid),
+	.addr(dbg_out_addr),
+	.data(dbg_ddram_data),
+	.wr_valid(dbg_wr_valid),
+	.wr_addr(dbg_wr_addr),
+	.wr_data(dbg_wr_data),
+	.base_addr(dbg_base_addr),
+
+	.pixel_color(ovl_color)
+);
+
+reg [1:0] ovl_color_sync;
+always @(posedge CLK_VIDEO) begin
+    ovl_color_sync <= ovl_color;
+end
+
 video_mixer #(.GAMMA(1)) video_mixer
 (
 	.CLK_VIDEO(CLK_VIDEO),
@@ -1363,9 +1586,10 @@ video_mixer #(.GAMMA(1)) video_mixer
 	.gamma_bus(gamma_bus),
 
 	.ce_pix(ce_pix),
-	.R(r),
-	.G(g),
-	.B(b),
+	 // overlay colors: 0=Transparent, 1=Green, 2=Yellow, 3=Red
+	.R((ovl_color_sync == 2 || ovl_color_sync == 3) ? 8'hFF : (ovl_color_sync == 1 ? 8'h00 : r)),
+	.G((ovl_color_sync == 1 || ovl_color_sync == 2) ? 8'hFF : (ovl_color_sync == 3 ? 8'h00 : g)),
+	.B((ovl_color_sync != 0) ? 8'h00 : b),
 	.HSync(hsync_out),
 	.VSync(vsync_out),
 	.HBlank(hblank),

--- a/files.qip
+++ b/files.qip
@@ -19,4 +19,5 @@ set_global_assignment -name VHDL_FILE rtl/fpga64_rgbcolor.vhd
 set_global_assignment -name VHDL_FILE rtl/fpga64_keyboard.vhd
 set_global_assignment -name VHDL_FILE rtl/fpga64_buslogic.vhd
 set_global_assignment -name VHDL_FILE rtl/fpga64_sid_iec.vhd
+set_global_assignment -name SYSTEMVERILOG_FILE rtl/drv_overlay.sv
 set_global_assignment -name SYSTEMVERILOG_FILE c64.sv

--- a/rtl/drv_overlay.sv
+++ b/rtl/drv_overlay.sv
@@ -1,0 +1,391 @@
+// ============================================================================
+// Drive OSD and Debug Overlay
+//
+// Functionality:
+// - Displays drive track/activity status (Activity Only, Mounted, or Debug).
+// - Generates a 2-bit color index to be blended into the final video output.
+// - Debug mode: monitors DDRAM read/write history and specific address ranges.
+//
+// Clocking & Timing:
+// - Pixel rendering and coordinate generation are gated by `ce` (~8MHz pixel clock)
+//   to reduce power and relax routing/timing constraints.
+// - only DDRAM snooping and video sync resets (hblank/vblank) run at full ~32MHz.
+//
+// Architecture:
+// - Rendering uses a 3-stage pipeline to ensure low combinatorial load and
+//   predictable timing closure. Video output lags coordinates by 3 `ce` cycles.
+// ============================================================================
+module drv_overlay (
+	input clk,
+	input ce,
+	input hblank,
+	input vblank,
+	input ntsc,
+
+	// Drive status
+	input [1:0] drive_osd_mode, // 0=Activity Only, 1=If Mounted, 2=Debug, 3=Off
+	input [1:0] drive_led,
+	input [1:0] drive_mounted,
+	input [6:0] drive_track_0,
+	input [6:0] drive_track_1,
+	input [1:0] drive_we,      // drive write enable or busy flushig tracks
+
+	// debug data
+	input valid,
+	input [31:0] addr,
+	input [63:0] data,
+	input wr_valid,
+	input [31:0] wr_addr,
+	input [63:0] wr_data,
+	input [31:0] base_addr,
+
+	// pixel output for video mixer
+	// 0=Transparent, 1=Green, 2=Yellow, 3=Red
+	output [1:0] pixel_color
+	);
+
+// Debug info
+// `hist_addr` and `hist_data` are rolling buffers for the last 8 DDRAM reads (addresses and value)
+// `snoop_data` captures data specifically for 8-dword window starting at `base_addr`.
+// The `wr_` prefixed variants do the same for write operations.
+reg [31:0] hist_addr [0:7]     = '{default:0};
+reg [63:0] hist_data [0:7]     = '{default:0};
+reg [63:0] snoop_data [0:7]    = '{default:0};
+
+reg [31:0] wr_hist_addr [0:7]  = '{default:0};
+reg [63:0] wr_hist_data [0:7]  = '{default:0};
+reg [63:0] wr_snoop_data [0:7] = '{default:0};
+
+integer i;
+always @(posedge clk) begin
+	if (valid) begin
+		for (i=7; i>0; i=i-1) begin
+			hist_addr[i] <= hist_addr[i-1];
+			hist_data[i] <= hist_data[i-1];
+		end
+		hist_addr[0] <= addr;
+		hist_data[0] <= data;
+
+		if (addr >= base_addr && addr < base_addr + 8) begin
+			snoop_data[3'(addr - base_addr)] <= data;
+		end
+	end
+
+	if (wr_valid) begin
+		for (i=7; i>0; i=i-1) begin
+			wr_hist_addr[i] <= wr_hist_addr[i-1];
+			wr_hist_data[i] <= wr_hist_data[i-1];
+		end
+		wr_hist_addr[0] <= wr_addr;
+		wr_hist_data[0] <= wr_data;
+
+		if (wr_addr >= base_addr && wr_addr < base_addr + 8) begin
+			wr_snoop_data[3'(wr_addr - base_addr)] <= wr_data;
+		end
+	end
+end
+
+// Coordinate Logic
+reg [9:0] x_pos = 0;
+reg [9:0] y_pos = 0;
+reg old_hblank = 0;
+
+always @(posedge clk) begin
+	if (hblank) x_pos <= 0;
+	else if (ce) x_pos <= x_pos + 1'd1;
+
+	if (ce) old_hblank <= hblank;
+
+	if (vblank) y_pos <= 0;
+	else if (ce) begin
+		if (old_hblank && ~hblank) y_pos <= y_pos + 1'd1;
+	end
+end
+
+// Overlay Areas
+wire debug_active = (drive_osd_mode == 2);
+wire dbg_area     = (x_pos >= 32) && (x_pos < 32 + 51*6) &&
+                    (y_pos >= 32) && (y_pos < 32 + 17*6);
+
+wire [9:0] base_y  = ntsc ? 10'd229 : 10'd237;
+wire [9:0] base_x  = ntsc ? 10'd323 : 10'd316;
+wire       drv_area = (x_pos >= base_x) && (x_pos < base_x + 42) &&
+                      (y_pos >= base_y) && (y_pos < base_y + 12);
+
+// Coordinate generators
+reg [5:0] dbg_col_r = 0;
+reg [4:0] dbg_row_r = 0;
+reg [2:0] dbg_px_r  = 0;
+reg [2:0] dbg_py_r  = 0;
+
+reg [2:0] drv_col_r = 0;
+reg       drv_row_r = 0;
+reg [2:0] drv_px_r  = 0;
+reg [2:0] drv_py_r  = 0;
+
+always @(posedge clk) begin
+	if (hblank) begin
+		dbg_col_r <= 0;
+		dbg_px_r  <= 0;
+		drv_col_r <= 0;
+		drv_px_r  <= 0;
+	end else if (ce) begin
+		if (x_pos == 32-1) begin
+			dbg_col_r <= 0;
+			dbg_px_r  <= 0;
+		end else if (dbg_area) begin
+			if (dbg_px_r == 5) begin
+				dbg_px_r  <= 0;
+				dbg_col_r <= dbg_col_r + 1'd1;
+			end else begin
+				dbg_px_r  <= dbg_px_r + 1'd1;
+			end
+		end
+
+		if (x_pos == base_x - 10'd1) begin
+			drv_col_r <= 0;
+			drv_px_r  <= 0;
+		end else if (drv_area) begin
+			if (drv_px_r == 5) begin
+				drv_px_r  <= 0;
+				drv_col_r <= drv_col_r + 1'd1;
+			end else begin
+				drv_px_r  <= drv_px_r + 1'd1;
+			end
+		end
+	end
+end
+
+always @(posedge clk) begin
+	if (vblank) begin
+		dbg_row_r <= 0;
+		dbg_py_r  <= 0;
+		drv_row_r <= 0;
+		drv_py_r  <= 0;
+	end else if (ce) begin
+		if (old_hblank && ~hblank) begin
+			if (y_pos == 32-1) begin
+				dbg_row_r <= 0;
+				dbg_py_r  <= 0;
+			end else if (dbg_area || (y_pos >= 32 && y_pos < 32 + 17*6)) begin
+				if (dbg_py_r == 5) begin
+					dbg_py_r  <= 0;
+					dbg_row_r <= dbg_row_r + 1'd1;
+				end else begin
+					dbg_py_r  <= dbg_py_r + 1'd1;
+				end
+			end else begin
+				dbg_row_r <= 0;
+				dbg_py_r  <= 0;
+			end
+
+			if (y_pos == base_y-1) begin
+				drv_row_r <= 0;
+				drv_py_r  <= 0;
+			end else if (drv_area || (y_pos >= base_y && y_pos < base_y + 12)) begin
+				if (drv_py_r == 5) begin
+					drv_py_r  <= 0;
+					drv_row_r <= drv_row_r + 1'd1;
+				end else begin
+					drv_py_r  <= drv_py_r + 1'd1;
+				end
+			end else begin
+				drv_row_r <= 0;
+				drv_py_r  <= 0;
+			end
+		end
+	end
+end
+
+wire [5:0] dbg_col = dbg_col_r;
+wire [4:0] dbg_row = dbg_row_r;
+wire [2:0] dbg_px  = dbg_px_r;
+wire [2:0] dbg_py  = dbg_py_r;
+
+wire [2:0] drv_col = drv_col_r;
+wire       drv_row = drv_row_r;
+wire [2:0] drv_px  = drv_px_r;
+wire [2:0] drv_py  = drv_py_r;
+
+
+// ---------------------------------------------------------------------------
+// DATA RESOLUTION (COMBINATORIAL)
+// ---------------------------------------------------------------------------
+
+reg [63:0] src_data;
+reg [3:0]  dbg_nibble;
+reg [3:0]  nibble_idx;
+
+always @(*) begin
+	dbg_nibble = 4'h0;
+	src_data   = 64'd0;
+	nibble_idx = 4'd0;
+
+	if (dbg_col < 51) begin
+		if (dbg_row < 8) begin
+			if (dbg_col < 8) begin
+				src_data   = {32'd0, hist_addr[dbg_row[2:0]]};
+				nibble_idx = 4'(7 - dbg_col);
+			end else if (dbg_col > 8 && dbg_col < 25) begin
+				src_data   = hist_data[dbg_row[2:0]];
+				nibble_idx = 4'(24 - dbg_col);
+			end else if (dbg_col >= 26 && dbg_col < 34) begin
+				src_data   = {32'd0, wr_hist_addr[dbg_row[2:0]]};
+				nibble_idx = 4'(33 - dbg_col);
+			end else if (dbg_col > 34 && dbg_col < 51) begin
+				src_data   = wr_hist_data[dbg_row[2:0]];
+				nibble_idx = 4'(50 - dbg_col);
+			end
+		end else if (dbg_row >= 9 && dbg_row < 17) begin
+			if (dbg_col < 8) begin
+				src_data   = {32'd0, base_addr + (dbg_row - 5'd9)};
+				nibble_idx = 4'(7 - dbg_col);
+			end else if (dbg_col > 8 && dbg_col < 25) begin
+				src_data   = snoop_data[dbg_row[2:0] - 3'd1];
+				nibble_idx = 4'(24 - dbg_col);
+			end else if (dbg_col >= 26 && dbg_col < 34) begin
+				src_data   = {32'd0, base_addr + (dbg_row - 5'd9)};
+				nibble_idx = 4'(33 - dbg_col);
+			end else if (dbg_col > 34 && dbg_col < 51) begin
+				src_data   = wr_snoop_data[dbg_row[2:0] - 3'd1];
+				nibble_idx = 4'(50 - dbg_col);
+			end
+		end
+
+		if (dbg_col != 8 && dbg_col != 25 && dbg_col != 34) begin
+			dbg_nibble = src_data[(nibble_idx * 4) +: 4];
+		end
+	end
+end
+
+wire active_row = (dbg_row < 8) || (dbg_row >= 9 && dbg_row < 17);
+wire valid_pixel_rd = dbg_area && active_row && debug_active && (dbg_px < 5) && (dbg_py < 5) && (dbg_col < 25) && (dbg_col != 8);
+wire valid_pixel_wr = dbg_area && active_row && debug_active && (dbg_px < 5) && (dbg_py < 5) && (dbg_col >= 26) && (dbg_col < 51) && (dbg_col != 34);
+
+reg [4:0]  drv_char;
+wire [6:0] drv_track  = drv_row ? drive_track_1 : drive_track_0;
+wire [6:0] full_track = (drv_track >> 1) + 7'd1;
+wire       half_track = drv_track[0];
+
+wire [3:0] track_tens = (full_track >= 80) ? 4'd8 : (full_track >= 70) ? 4'd7 : (full_track >= 60) ? 4'd6 :
+                        (full_track >= 50) ? 4'd5 : (full_track >= 40) ? 4'd4 : (full_track >= 30) ? 4'd3 :
+                        (full_track >= 20) ? 4'd2 : (full_track >= 10) ? 4'd1 : 4'd0;
+wire [3:0] track_ones = 4'(full_track - ((track_tens << 3) + (track_tens << 1)));
+
+always @(*) begin
+	case (drv_col)
+		0: drv_char = 5'h10; // '#'
+		1: drv_char = drv_row ? 5'h09 : 5'h08; // '9' or '8'
+		2: drv_char = 5'h11; // ' '
+		3: drv_char = (track_tens == 0) ? 5'h11 : {1'b0, track_tens};
+		4: drv_char = {1'b0, track_ones};
+		5: drv_char = half_track ? 5'h12 : 5'h11; // '.' or ' '
+		6: drv_char = half_track ? 5'h05 : 5'h11; // '5' or ' '
+		default: drv_char = 5'h11;
+	endcase
+end
+
+wire drv_led_act     = drive_led[drv_row];
+wire drv_we_act      = drive_we[drv_row];
+wire valid_osd_pixel = drv_area && (drv_px < 5) && (drv_py < 5) &&
+					   ((drive_osd_mode == 0 && drv_led_act) ||
+					   (drive_osd_mode == 1 && drive_mounted[drv_row]) ||
+					   drive_osd_mode == 2);
+
+
+// ---------------------------------------------------------------------------
+// PIPELINE STAGE 1: Latch coordinates, character inputs, and state flags
+// ---------------------------------------------------------------------------
+reg [4:0] char_to_draw_s1;
+reg [2:0] px_s1;
+reg [2:0] py_s1;
+
+reg valid_osd_s1, valid_rd_s1, valid_wr_s1;
+reg drv_led_act_s1, drv_we_act_s1;
+
+always @(posedge clk) begin
+	if (ce) begin
+		char_to_draw_s1 <= valid_osd_pixel ? drv_char : {1'b0, dbg_nibble};
+		px_s1           <= valid_osd_pixel ? drv_px   : dbg_px;
+		py_s1           <= valid_osd_pixel ? drv_py   : dbg_py;
+
+		valid_osd_s1    <= valid_osd_pixel;
+		valid_rd_s1     <= valid_pixel_rd;
+		valid_wr_s1     <= valid_pixel_wr;
+		drv_led_act_s1  <= drv_led_act;
+		drv_we_act_s1   <= drv_we_act;
+	end
+end
+
+
+// ---------------------------------------------------------------------------
+// PIPELINE STAGE 2: Font ROM Lookup
+// ---------------------------------------------------------------------------
+reg [4:0] font_row_s2;
+reg [2:0] px_s2;
+
+reg valid_osd_s2, valid_rd_s2, valid_wr_s2;
+reg drv_led_act_s2, drv_we_act_s2;
+
+always @(posedge clk) begin
+	if (ce) begin
+		// Font Lookup
+		case (char_to_draw_s1)
+			5'h00: case(py_s1) 0: font_row_s2<=5'b01110; 1: font_row_s2<=5'b10001; 2: font_row_s2<=5'b10001; 3: font_row_s2<=5'b10001; 4: font_row_s2<=5'b01110; default: font_row_s2<=0; endcase
+			5'h01: case(py_s1) 0: font_row_s2<=5'b00100; 1: font_row_s2<=5'b01100; 2: font_row_s2<=5'b00100; 3: font_row_s2<=5'b00100; 4: font_row_s2<=5'b01110; default: font_row_s2<=0; endcase
+			5'h02: case(py_s1) 0: font_row_s2<=5'b01110; 1: font_row_s2<=5'b10001; 2: font_row_s2<=5'b00110; 3: font_row_s2<=5'b01000; 4: font_row_s2<=5'b11111; default: font_row_s2<=0; endcase
+			5'h03: case(py_s1) 0: font_row_s2<=5'b11110; 1: font_row_s2<=5'b00001; 2: font_row_s2<=5'b01110; 3: font_row_s2<=5'b00001; 4: font_row_s2<=5'b11110; default: font_row_s2<=0; endcase
+			5'h04: case(py_s1) 0: font_row_s2<=5'b10001; 1: font_row_s2<=5'b10001; 2: font_row_s2<=5'b11111; 3: font_row_s2<=5'b00001; 4: font_row_s2<=5'b00001; default: font_row_s2<=0; endcase
+			5'h05: case(py_s1) 0: font_row_s2<=5'b11111; 1: font_row_s2<=5'b10000; 2: font_row_s2<=5'b11110; 3: font_row_s2<=5'b00001; 4: font_row_s2<=5'b11110; default: font_row_s2<=0; endcase
+			5'h06: case(py_s1) 0: font_row_s2<=5'b01110; 1: font_row_s2<=5'b10000; 2: font_row_s2<=5'b11110; 3: font_row_s2<=5'b10001; 4: font_row_s2<=5'b01110; default: font_row_s2<=0; endcase
+			5'h07: case(py_s1) 0: font_row_s2<=5'b11111; 1: font_row_s2<=5'b00001; 2: font_row_s2<=5'b00010; 3: font_row_s2<=5'b00100; 4: font_row_s2<=5'b00100; default: font_row_s2<=0; endcase
+			5'h08: case(py_s1) 0: font_row_s2<=5'b01110; 1: font_row_s2<=5'b10001; 2: font_row_s2<=5'b01110; 3: font_row_s2<=5'b10001; 4: font_row_s2<=5'b01110; default: font_row_s2<=0; endcase
+			5'h09: case(py_s1) 0: font_row_s2<=5'b01110; 1: font_row_s2<=5'b10001; 2: font_row_s2<=5'b01111; 3: font_row_s2<=5'b00001; 4: font_row_s2<=5'b01110; default: font_row_s2<=0; endcase
+			5'h0A: case(py_s1) 0: font_row_s2<=5'b01110; 1: font_row_s2<=5'b10001; 2: font_row_s2<=5'b11111; 3: font_row_s2<=5'b10001; 4: font_row_s2<=5'b10001; default: font_row_s2<=0; endcase
+			5'h0B: case(py_s1) 0: font_row_s2<=5'b11110; 1: font_row_s2<=5'b10001; 2: font_row_s2<=5'b11110; 3: font_row_s2<=5'b10001; 4: font_row_s2<=5'b11110; default: font_row_s2<=0; endcase
+			5'h0C: case(py_s1) 0: font_row_s2<=5'b01110; 1: font_row_s2<=5'b10000; 2: font_row_s2<=5'b10000; 3: font_row_s2<=5'b10000; 4: font_row_s2<=5'b01110; default: font_row_s2<=0; endcase
+			5'h0D: case(py_s1) 0: font_row_s2<=5'b11110; 1: font_row_s2<=5'b10001; 2: font_row_s2<=5'b10001; 3: font_row_s2<=5'b10001; 4: font_row_s2<=5'b11110; default: font_row_s2<=0; endcase
+			5'h0E: case(py_s1) 0: font_row_s2<=5'b11111; 1: font_row_s2<=5'b10000; 2: font_row_s2<=5'b11110; 3: font_row_s2<=5'b10000; 4: font_row_s2<=5'b11111; default: font_row_s2<=0; endcase
+			5'h0F: case(py_s1) 0: font_row_s2<=5'b11111; 1: font_row_s2<=5'b10000; 2: font_row_s2<=5'b11110; 3: font_row_s2<=5'b10000; 4: font_row_s2<=5'b10000; default: font_row_s2<=0; endcase
+			5'h10: case(py_s1) 0: font_row_s2<=5'b01010; 1: font_row_s2<=5'b11111; 2: font_row_s2<=5'b01010; 3: font_row_s2<=5'b11111; 4: font_row_s2<=5'b01010; default: font_row_s2<=0; endcase // '#'
+			5'h11: case(py_s1) 0: font_row_s2<=5'b00000; 1: font_row_s2<=5'b00000; 2: font_row_s2<=5'b00000; 3: font_row_s2<=5'b00000; 4: font_row_s2<=5'b00000; default: font_row_s2<=0; endcase // ' '
+			5'h12: case(py_s1) 0: font_row_s2<=5'b00000; 1: font_row_s2<=5'b00000; 2: font_row_s2<=5'b00000; 3: font_row_s2<=5'b01100; 4: font_row_s2<=5'b01100; default: font_row_s2<=0; endcase // '.'
+			default: font_row_s2<=0;
+		endcase
+
+		// Forward state
+		px_s2          <= px_s1;
+		valid_osd_s2   <= valid_osd_s1;
+		valid_rd_s2    <= valid_rd_s1;
+		valid_wr_s2    <= valid_wr_s1;
+		drv_led_act_s2 <= drv_led_act_s1;
+		drv_we_act_s2  <= drv_we_act_s1;
+	end
+end
+
+
+// ---------------------------------------------------------------------------
+// PIPELINE STAGE 3: Final Pixel Shift and Color Mixing
+// ---------------------------------------------------------------------------
+wire [2:0] px_rev = (px_s2 < 5) ? 3'd4 - px_s2 : 3'd0;
+wire pixel_base   = (px_s2 < 5) ? font_row_s2[px_rev] : 1'b0;
+
+reg [1:0] pixel_color_out;
+
+always @(posedge clk) begin
+	if (ce) begin
+		if (valid_osd_s2 && pixel_base && drv_led_act_s2 && drv_we_act_s2) begin
+			pixel_color_out <= 2'd3; // Red (Drive Write)
+		end else if ((valid_osd_s2 && pixel_base && drv_led_act_s2 && ~drv_we_act_s2) || (valid_wr_s2 && pixel_base)) begin
+			pixel_color_out <= 2'd2; // Yellow (Drive Read or Debug Write)
+		end else if ((valid_osd_s2 && pixel_base && ~drv_led_act_s2) || (valid_rd_s2 && pixel_base)) begin
+			pixel_color_out <= 2'd1; // Green (Drive Idle or Debug Read)
+		end else begin
+			pixel_color_out <= 2'd0; // Transparent
+		end
+	end
+end
+
+assign pixel_color = pixel_color_out;
+
+endmodule

--- a/rtl/iec_drive/c1541_direct_gcr.sv
+++ b/rtl/iec_drive/c1541_direct_gcr.sv
@@ -3,13 +3,20 @@
 // C1541 direct gcr module
 // (C) 2021 Alexey Melnikov
 //
+// ------------------------------------------------------------------------------
+// Major Updates 2025/2026 by Robin Wünderlich:
+//  - low level read logic (based on schematics)
+//  - disk rotation simulation
+//  - non blocking track read/write
+//  - AGC flux events (weak bits)
+//  - 64 bit track buffer
+//  - skew preserving track change
 //
-// disk rotation and low level read logic based on schematics by Robin Wünderlich
 // TODO:
 // - investigate potential T65 inaccurate so_n handling (e.g. not preventing
 // so_n sampling for upto 2 cycles into next instruction after an instruction
 // sets/clears overflow)
-// - improve support code speed of track data delivery
+//
 //-------------------------------------------------------------------------------
 
 module c1541_direct_gcr
@@ -30,33 +37,35 @@ module c1541_direct_gcr
 	output       sync_n,
 	output       byte_n,
 
-	input        busy,
+	input        disk_present,
 	output       we,
 
-	input        sd_clk,
-	input [13:0] sd_buff_addr,
-	input  [7:0] sd_buff_dout,
-	output [7:0] sd_buff_din,
-	input        sd_buff_wr
+	input         sd_clk,
+	input  [13:0] sd_buff_addr,
+	input  [63:0] sd_buff_dout,
+	output [63:0] sd_buff_din,
+	input         sd_buff_wr
 );
 
 assign we          = buff_we;
-assign sd_buff_din = (sd_buff_addr >= track_len_adj + 2) ? 8'hFF : sd_buff_do;
+assign sd_buff_din = (sd_buff_addr[13:3] >= ((track_len_adj + 13'd9) >> 3)) ?
+					 64'hFFFFFFFFFFFFFFFF : sd_buff_do;
 assign dout        = shreg[7:0];
 
 reg [12:0] track_len, track_new, len_valid;
-always @(posedge sd_clk) if(sd_buff_wr && !sd_buff_addr[13:1]) begin
-	// size and possible flags
-	if(sd_buff_addr[0] == 0) track_new[7:0]  <= sd_buff_dout;
-	if(sd_buff_addr[0] == 1) track_new[12:8] <= sd_buff_dout[4:0];
+
+// snoop track size
+wire len_update = sd_buff_wr && (sd_buff_addr[13:3] == 0);
+always @(posedge sd_clk) if(len_update) begin
+	track_new[12:0] <= sd_buff_dout[12:0];
 end
 
-wire [7:0] sd_buff_do;
-iecdrv_bitmem #(13) buffer
+iecdrv_bitmem64 #(10) buffer
 (
 	.clock_a(sd_clk),
-	.address_a(sd_buff_addr[12:0]),
+	.address_a(sd_buff_addr[12:3]),
 	.data_a(sd_buff_dout),
+	// wrap-around write protection
 	.wren_a(sd_buff_wr & ~sd_buff_addr[13]),
 	.q_a(sd_buff_do),
 
@@ -67,15 +76,18 @@ iecdrv_bitmem #(13) buffer
 	.q_b(buff_do)
 );
 
+wire [63:0] sd_buff_do;
 reg  [15:0] buff_addr;
 reg   [7:0] buff_di;
 wire        buff_do;
 reg         buff_we;
 
-wire [30:0] random_data;
-random lfsr(
-   .clock(clk),
-   .lfsr(random_data)
+wire [31:0] random_data;
+random_xor lfsr(
+	.clock(clk),
+	.reset(reset),
+	.seed(0),
+	.lfsr(random_data)
 );
 
 // 1541 part designations are based on the schematics in:
@@ -84,13 +96,13 @@ random lfsr(
 // which are referenced by their 1540 designations
 assign sync_n = ~&shreg | ~mode;                               // UC2  (UC1)
 assign byte_n = ~&UE3_bit_cnt | &shreg | UF4_enc_phase_cnt[1]; // UF3C (UC1) (soe: c1541_logic)
+
 reg  [9:0] shreg;              // UD2 74LS164, UE4A+UE4B 74LS74 (UC1)
 reg  [3:0] UF4_enc_phase_cnt;  // 74LS193 (UC1)
 reg  [3:0] UE6_enc_clk_cnt;    // 74LS193
 reg  [2:0] UE3_bit_cnt;        // 74LS191 (UC1)
 reg  [2:0] UD3_bit_cnt_w;      // 74LS165 (UC1)
-reg  [5:0] UD4A_cnt;           // 9602
-reg  [8:0] flux_cnt;
+reg  [9:0] flux_cnt;
 reg        hf;                 // data from head
 reg        ht;                 // data to head
 
@@ -101,15 +113,16 @@ reg        ht;                 // data to head
 localparam        BASE_RPM         =         300;
 localparam        CLK_FREQ         =  16_000_000;
 localparam        BASE_ROT_TARGET  =     400_000;
-localparam        WBL_FREQ         =          43; // WPM* 10
-localparam        WBL_MAX          =          21; // RPM*100
+localparam        WBL_FREQ         =          45; // WPM * 10
+localparam        WBL_MAX          =          24; // RPM * 100
 localparam        WBL_CLKS_PER_STP = (((CLK_FREQ/(4*WBL_MAX_OFFSET)) * 600) / WBL_FREQ);
 localparam signed WBL_MAX_OFFSET   = ((BASE_ROT_TARGET/ 100) * WBL_MAX)/BASE_RPM;
 
-wire [18:0] base_rot_targets[8] = '{19'd400_000, 19'd398_671, 19'd397_351, 19'd393_443,
-                                    19'd387_097, 19'd406_780, 19'd402_685, 19'd401_338};
+wire [18:0] base_rot_targets[8] = '{19'd400_000, 19'd399_867, 19'd399_334, 19'd398_671,
+                                    19'd397_351, 19'd401_338, 19'd400_668, 19'd400_133};
 
-wire       [19:0] rot_target = $signed({1'b0, base_rot_targets[drive_rpm]}) + (drive_wobble ? wbl_offset : 10'sd0);
+wire       [19:0] rot_target = $signed({1'b0, base_rot_targets[drive_rpm]})
+							   + (drive_wobble ? wbl_offset : 10'sd0);
 reg        [19:0] rot_clk_cnt;
 reg        [31:0] wbl_step_cnt;
 reg signed [9:0]  wbl_offset;
@@ -119,12 +132,13 @@ reg               wbl_dir;
 wire [12:0] track_new_adj = (track_new > 'd6000) ? track_new : len_valid;
 wire [12:0] track_len_adj = (track_len > 'd6000) ? track_len : len_valid;
 wire [13:0] recip = rec[track_len_adj-6000];
+wire buff_do_adj = (track_len > 'd6000) ? buff_do : buff_addr[0];
 
 // precalc reciprocals for track_len_adj = 6000 .. 8047
-reg  [13:0] rec[0:2047];
+reg  [13:0] rec[0:2191] = '{default:0};
 initial begin
 	integer i;
-	for(i = 0; i < 2048; i = i + 1) begin
+	for(i = 0; i < 2192; i = i + 1) begin
 		rec[i] = 14'((1 << 26) / (i + 6000));
 	end
 end
@@ -133,6 +147,9 @@ always @(posedge clk) begin
 	buff_we <= 0;
 
 	if(reset) begin
+		// Drive inferred ROM's write ports to silence warning 10030 cleanly
+		rec[0] <= 14'((1 << 26) / (0 + 6000));
+
 		buff_addr           <= 16;
 		UE3_bit_cnt         <= 0;
 		UD3_bit_cnt_w       <= 0;
@@ -142,15 +159,12 @@ always @(posedge clk) begin
 		rot_clk_cnt         <= 0;
 		UF4_enc_phase_cnt   <= 0;
 		UE6_enc_clk_cnt     <= 0;
-		UD4A_cnt            <= 0;
-		flux_cnt            <= 9'd288;
+		flux_cnt            <= 10'd256;
 		wbl_offset          <= 0;
 		wbl_step_cnt        <= 0;
 		wbl_dir             <= 0;
 		track_len           <= 0;
 		len_valid           <= 'd7142;
-	end
-	else if(busy) begin
 	end
 	else if(ce) begin
 
@@ -160,7 +174,7 @@ always @(posedge clk) begin
 		if(mode) begin
 			if(rot_clk_cnt >= rot_target) begin
 				rot_clk_cnt <=  rot_clk_cnt - rot_target + track_len_adj;
-				if(track_new == track_len) begin
+				if (track_new_adj == track_len_adj) begin
 					if(buff_addr >= {track_len_adj + 1'd1, 3'b111})
 						buff_addr <= 16'd16;
 					else begin
@@ -172,38 +186,40 @@ always @(posedge clk) begin
 				else rot_clk_cnt <= 0;
 		end else
 			if(&UE6_enc_clk_cnt && (UF4_enc_phase_cnt[1:0] == 2'b01)) begin
-				if(buff_addr >= {track_len + 1'd1, 3'b111}) buff_addr <= 16;
+				if(buff_addr >= {track_len_adj + 1'd1, 3'b111}) buff_addr <= 16;
 				else buff_addr <=  buff_addr + 1'd1;
 			end
 
 		// drivers of hf (flux reversals from data, or random flux reversals)
-		if(!mode)                          hf <= 0;
-		else if(!flux_cnt)                 hf <= 1;
-		else if(busy)                      hf <= 0;
-		else if(track_len <= 6000)         hf <= 0;
-		else if(rot_clk_cnt >= rot_target) hf <= buff_do;
-		else                               hf <= 0;  // demux dogma
+		if(!mode)                                          hf <= 0;
+		else if(!flux_cnt)                                 hf <= 1;
+		else if(disk_present && rot_clk_cnt >= rot_target) hf <= buff_do_adj;
+		else                                               hf <= 0;  // demux dogma
 
-		// random flux reversal counters (weak bits/bad gcr)
-		if(hf) begin
-			if(!flux_cnt)  flux_cnt <= random_data[7:0] + 9'd37;
-			else           flux_cnt <= random_data[4:0] + 9'd288;
+		// random flux reversal counter (weak bits/bad gcr)
+		if(!flux_cnt)
+		   flux_cnt <= random_data[6:0] + 10'd40;
+		else if((rot_clk_cnt >= rot_target) && buff_do_adj)
+		   flux_cnt <= random_data[5:0] + 10'd256;
+		   else flux_cnt <= flux_cnt - 1'b1;
+
+		// encoder-decoder clock, divider based on freq
+		// flux reversals reset UE6 and UF4 counters
+		if (hf) begin
+			UE6_enc_clk_cnt   <= {2'b00,freq};
+			UF4_enc_phase_cnt <= 0;
+		end else if (&UE6_enc_clk_cnt) begin
+			UE6_enc_clk_cnt   <= {2'b00,freq};
+			UF4_enc_phase_cnt <= UF4_enc_phase_cnt + 1'b1;
+		end else begin
+			UE6_enc_clk_cnt   <= UE6_enc_clk_cnt + 1'b1;
 		end
-		else if(flux_cnt) flux_cnt <= flux_cnt - 1'b1;
-
-		// encoder-decoder clock divider based on freq
-		if(&UE6_enc_clk_cnt) begin
-			UE6_enc_clk_cnt <= {2'b00,freq};
-		end else
-			UE6_enc_clk_cnt <= UE6_enc_clk_cnt + 1'b1;
 
 		// encoder-decoder
-		// flux reversals reset (see filter stage below) UE6 and UF4 counters
 		// a one bit will be clocked into the shift register in phase b0010.
 		// if the allowed time window expires without a flux reversal 0 bits
 		// will be clocked into the shift register (phases b0110, b1010 etc.)
 		if(&UE6_enc_clk_cnt) begin
-			UF4_enc_phase_cnt <= UF4_enc_phase_cnt + 1'b1;
 			// transition into phase bxx10
 			if(UF4_enc_phase_cnt[1:0] == 2'b01) begin
 				shreg          <= {shreg[8:0], ~|UF4_enc_phase_cnt[3:2]}; // UE5a (UC1)
@@ -224,25 +240,14 @@ always @(posedge clk) begin
 			end
 		end
 
-		// detected flux reversals are validated by a filter stage
-		// as we only model valid flux reversals the effect is a
-		// 2.5us delay (40clks = 64-24) of the UE6/UF4 counter reset
-		if (UD4A_cnt) begin
-			UD4A_cnt <= UD4A_cnt + 1'b1;
-			if (&UD4A_cnt) begin
-				UE6_enc_clk_cnt   <= {2'b00,freq};
-				UF4_enc_phase_cnt <= 0;
-			end
-		end else if(hf) UD4A_cnt <= 6'd24;
-
 		if(~sync_n) UE3_bit_cnt <= 0;
 
 		// drive wobble
 		if(wbl_step_cnt >= WBL_CLKS_PER_STP) begin
 			wbl_step_cnt <= 0;
 			wbl_dir      <= (wbl_offset >  WBL_MAX_OFFSET) ? 1'b0 :
-                         (wbl_offset < -WBL_MAX_OFFSET) ? 1'b1 :
-                          wbl_dir;
+							(wbl_offset < -WBL_MAX_OFFSET) ? 1'b1 :
+							wbl_dir;
 			wbl_offset   <= wbl_offset + (wbl_dir ? 10'sd1 : -10'sd1);
 		end else
 			wbl_step_cnt <= wbl_step_cnt + 1'b1;
@@ -250,10 +255,10 @@ always @(posedge clk) begin
 		// adjustment for disk geometry if head moves to new track
 		// use valid length of neighbouring track as proxy for empty track
 		track_len <= track_new;
-		if(track_new != track_len) begin
+		if(track_new_adj != track_len_adj) begin
 			if(track_new > 'd6000) len_valid <= track_new;
 			buff_addr <= 16'(((43'h0 + ((buff_addr - 16) * track_new_adj)) * recip) >> 26) + 16'd16;
-		end
+			end
 	end
 end
 

--- a/rtl/iec_drive/c1541_drv.sv
+++ b/rtl/iec_drive/c1541_drv.sv
@@ -13,7 +13,7 @@
 //                             : remove iec internal OR wired
 //                             : synched atn_in (sometime no IRQ with real c64)
 //
-// Input clk 16MHz
+// Input clk ~32MHz (clk_sys from top level, previously labeled 16MHz)
 //
 //-------------------------------------------------------------------------------
 
@@ -39,6 +39,8 @@ module c1541_drv
 
 	input   [1:0] drive_num,
 	output        led,
+	output wire [6:0] out_track,
+	output wire    out_we,
 
 	input         iec_atn_i,
 	input         iec_data_i,
@@ -67,12 +69,24 @@ module c1541_drv
 	input  [13:0] sd_buff_addr,
 	input   [7:0] sd_buff_dout,
 	output  [7:0] sd_buff_din,
-	input         sd_buff_wr
+	input         sd_buff_wr,
+
+	input         DDRAM_BUSY,
+	output  [7:0] DDRAM_BURSTCNT,
+	output [28:0] DDRAM_ADDR,
+	input  [63:0] DDRAM_DOUT,
+	input         DDRAM_DOUT_READY,
+	output        DDRAM_RD,
+	output        DDRAM_WE,
+	output [63:0] DDRAM_DIN,
+	output  [7:0] DDRAM_BE
 );
 
-assign led = act | sd_busy;
+assign led       = act;
+assign out_track = track;
+assign out_we    = track_modified | busy_flushing_s;
 
-reg        readonly = 0;
+reg        readonly     = 0;
 reg        disk_present = 0;
 reg [24:0] ch_timeout;
 always @(posedge clk) begin
@@ -127,56 +141,32 @@ c1541_logic c1541_logic
 
 	// drive-side interface
 	.ds(drive_num),
-	.din(gcr_mode ? dgcr_do : gcr_do),
-	.dout(gcr_di),
+	.din(dgcr_do),
+	.dout(dgcr_di),
 	.mode(mode),
 	.stp(stp),
 	.mtr(mtr),
 	.freq(freq),
-	.sync_n(gcr_mode ? dgcr_sync_n : gcr_sync_n),
-	.byte_n(gcr_mode ? dgcr_byte_n : gcr_byte_n),
+	.sync_n(dgcr_sync_n),
+	.byte_n(dgcr_byte_n),
 	.wps_n(wps_n),
 	.tr00_sense_n(|track),
 	.act(act)
 );
 
-wire  [7:0] gcr_di;
-wire        we = gcr_mode ? dgcr_we : gcr_we;
-assign      sd_buff_din = gcr_mode ? dgcr_sd_buff_dout : gcr_sd_buff_dout;
+iecdrv_sync dirty_sync(clk, busy_flushing, busy_flushing_s);
+wire        we = dgcr_we;
+wire [7:0]  dgcr_do,dgcr_di;
+wire [63:0] dgcr_sd_buff_dout;
+wire        dgcr_sync_n, dgcr_byte_n, dgcr_we;
+wire [13:0] dma_buff_addr;
+wire [63:0] dma_buff_dout;
+wire        dma_buff_wr;
+wire        dma_active;
 
-wire sd_busy;
-iecdrv_sync busy_sync(clk, busy, sd_busy);
-
-wire [7:0]  gcr_do, gcr_sd_buff_dout;
-wire        gcr_sync_n, gcr_byte_n, gcr_we;
-
-c1541_gcr c1541_gcr
-(
-	.clk(clk),
-	.ce(ce & ~gcr_mode),
-	
-	.dout(gcr_do),
-	.din(gcr_di),
-	.mode(mode),
-	.mtr(mtr),
-	.freq(freq),
-	.sync_n(gcr_sync_n),
-	.byte_n(gcr_byte_n),
-
-	.track(track[6:1]+1'd1),
-	.busy(sd_busy | ~disk_present),
-	.we(gcr_we),
-
-	.sd_clk(clk_sys),
-	.sd_lba(sd_lba),
-	.sd_buff_addr(sd_buff_addr[12:0]),
-	.sd_buff_dout(sd_buff_dout),
-	.sd_buff_din(gcr_sd_buff_dout),
-	.sd_buff_wr(sd_ack & sd_buff_wr & ~gcr_mode)
-);
-
-wire [7:0] dgcr_do, dgcr_sd_buff_dout;
-wire       dgcr_sync_n, dgcr_byte_n, dgcr_we;
+// Interface bg_buff (64bit) to sd_buff (8bit)
+wire [63:0] bg_buff_dout;
+assign      sd_buff_din = bg_buff_dout[(sd_buff_addr[2:0]*8) +: 8];
 
 c1541_direct_gcr c1541_direct_gcr
 (
@@ -188,7 +178,7 @@ c1541_direct_gcr c1541_direct_gcr
 	.drive_wobble(drive_wobble),
 	
 	.dout(dgcr_do),
-	.din(gcr_di),
+	.din(dgcr_di),
 	.mode(mode),
 	.mtr(mtr),
 	.freq(freq),
@@ -196,17 +186,18 @@ c1541_direct_gcr c1541_direct_gcr
 	.sync_n(dgcr_sync_n),
 	.byte_n(dgcr_byte_n),
 
-	.busy(sd_busy | ~disk_present),
+	.disk_present(disk_present),
 	.we(dgcr_we),
 
 	.sd_clk(clk_sys),
-	.sd_buff_addr(sd_buff_addr),
-	.sd_buff_dout(sd_buff_dout),
+	.sd_buff_addr(dma_buff_addr),
+	.sd_buff_dout(dma_buff_dout),
 	.sd_buff_din(dgcr_sd_buff_dout),
-	.sd_buff_wr(sd_ack & sd_buff_wr & gcr_mode)
+	.sd_buff_wr(dma_buff_wr)
 );
 
-wire busy;
+wire busy_flushing;
+wire busy_flushing_s;
 
 c1541_track c1541_track
 (
@@ -224,13 +215,33 @@ c1541_track c1541_track
 	.save_track(save_track),
 	.change(img_mounted),
 	.track(track),
-	.busy(busy)
+	.busy_flushing(busy_flushing),
+	.drive_num(drive_num[0]),
+
+	.DDRAM_BUSY(DDRAM_BUSY),
+	.DDRAM_BURSTCNT(DDRAM_BURSTCNT),
+	.DDRAM_ADDR(DDRAM_ADDR),
+	.DDRAM_DOUT(DDRAM_DOUT),
+	.DDRAM_DOUT_READY(DDRAM_DOUT_READY),
+	.DDRAM_RD(DDRAM_RD),
+	.DDRAM_WE(DDRAM_WE),
+	.DDRAM_DIN(DDRAM_DIN),
+	.DDRAM_BE(DDRAM_BE),
+
+	.dma_buff_addr(dma_buff_addr),
+	.dma_buff_dout(dma_buff_dout),
+	.dma_buff_wr(dma_buff_wr),
+	.dma_buff_din(dgcr_sd_buff_dout),
+
+	.sd_buff_addr(sd_buff_addr),
+	.bg_buff_dout(bg_buff_dout)
 );
 
 reg [6:0] track;
 reg       save_track = 0;
+reg [23:0] read_timer = 0;
+reg        track_modified = 0;
 always @(posedge clk) begin
-	reg       track_modified;
 	reg [6:0] track_num;
 	reg [1:0] move, stp_old;
 
@@ -239,25 +250,46 @@ always @(posedge clk) begin
 	stp_old <= stp;
 	move <= stp - stp_old;
 
-	if (we)          track_modified <= 1;
-	if (img_mounted) track_modified <= 0;
+	if (we && disk_present) track_modified <= 1;
+	if (img_mounted)        track_modified <= 0;
 
 	if (reset) begin
-		track_num <= 36;
+		track_num <= 34;
 		track_modified <= 0;
 	end else begin
 		if (mtr & move[0]) begin
 			if (~move[1] && track_num < 84) track_num <= track_num + 1'b1;
 			if ( move[1] && track_num > 0 ) track_num <= track_num - 1'b1;
+			// must save modified track on track change
 			if (track_modified) save_track <= ~save_track;
 			track_modified <= 0;
 		end
 
-		if (track_modified & ~act) begin	// stopping activity
+		// Save Track Strategy:
+		// balance SD longevity against data integrity by aggregating writes.
+		//
+		// Trade-offs:
+		// - DOS motor-off is too sluggish (~2s) for modern users.
+		// - DOS write-patterns (sector-by-sector) cause 20+ cycles per track.
+		// - Poorly behaved software (e.g., track copiers) abuses the LED and motor states.
+		//
+		// Strategy:
+		// We use a Write->Read transition timeout. If the drive has been in read mode for
+		// ~500ms since the last write, we assume inactivity and save the track.
+		// We also save immediately if the motor turns off.
+		if (track_modified && ((mode && read_timer == 24'd16_000_000) || !mtr)) begin
 			save_track <= ~save_track;
 			track_modified <= 0;
 		end
 	end
+
+	// Timer for read inactivity (500ms at ~32MHz = 16,000,000 cycles)
+	if (!mode) begin // mode 0 = writing
+		read_timer <= 0;
+	end else if (read_timer != 24'd16_000_000) begin
+		read_timer <= read_timer + 1'd1;
+	end
+
 end
 
 endmodule

--- a/rtl/iec_drive/c1541_multi.sv
+++ b/rtl/iec_drive/c1541_multi.sv
@@ -5,6 +5,8 @@
 //
 // Input clock/ce 16MHz
 //
+//
+// DDRAM arbiter by Robin Wünderlich
 //-------------------------------------------------------------------------------
 
 
@@ -25,6 +27,8 @@ module c1541_multi #(parameter PARPORT=1,DUALROM=1,DRIVES=2)
 	input         drive_wobble,
 
 	output  [N:0] led,
+	output wire [6:0] out_track[NDR],
+	output wire [N:0] out_we,
 	output        disk_ready,
 
 	input         iec_atn_i,
@@ -55,7 +59,17 @@ module c1541_multi #(parameter PARPORT=1,DUALROM=1,DRIVES=2)
 	input  [14:0] rom_addr,
 	input   [7:0] rom_data,
 	input         rom_wr,
-	input         rom_std
+	input         rom_std,
+
+	input         DDRAM_BUSY,
+	output  [7:0] DDRAM_BURSTCNT,
+	output [28:0] DDRAM_ADDR,
+	input  [63:0] DDRAM_DOUT,
+	input         DDRAM_DOUT_READY,
+	output        DDRAM_RD,
+	output        DDRAM_WE,
+	output [63:0] DDRAM_DIN,
+	output  [7:0] DDRAM_BE
 );
 
 localparam NDR = (DRIVES < 1) ? 1 : (DRIVES > 4) ? 4 : DRIVES;
@@ -207,6 +221,8 @@ generate
 
 			.drive_num(i),
 			.led(led_drv[i]),
+			.out_track(out_track[i]),
+			.out_we(out_we[i]),
 			.disk_ready(i_disk_ready[i]),
 
 			.iec_atn_i(iec_atn),
@@ -234,9 +250,90 @@ generate
 			.sd_buff_addr(sd_buff_addr),
 			.sd_buff_dout(sd_buff_dout),
 			.sd_buff_din(sd_buff_din[i]),
-			.sd_buff_wr(sd_buff_wr)
+			.sd_buff_wr(sd_buff_wr),
+
+			.DDRAM_BUSY(arb_ddram_busy[i]),
+			.DDRAM_DOUT(DDRAM_DOUT),
+			.DDRAM_DOUT_READY(arb_ddram_ready[i]),
+			.DDRAM_BURSTCNT(drv_ddram_burstcnt[i]),
+			.DDRAM_ADDR(drv_ddram_addr[i]),
+			.DDRAM_RD(drv_ddram_rd[i]),
+			.DDRAM_WE(drv_ddram_we[i]),
+			.DDRAM_DIN(drv_ddram_din[i]),
+			.DDRAM_BE(drv_ddram_be[i])
 		);
 	end
 endgenerate
+
+wire [7:0]  drv_ddram_burstcnt[NDR];
+wire [28:0] drv_ddram_addr[NDR];
+wire        arb_ddram_busy[NDR];
+wire        arb_ddram_ready[NDR];
+wire        drv_ddram_rd[NDR];
+wire        drv_ddram_we[NDR];
+wire [63:0] drv_ddram_din[NDR];
+wire  [7:0] drv_ddram_be[NDR];
+
+// ==============================================================================
+// DDRAM Round-Robin Arbiter (Supports Read Bursts)
+// ==============================================================================
+
+reg [1:0] arb_rr_state;
+reg       arb_is_locked;
+reg [7:0] burst_remaining;
+
+// MUX: Route signals for the currently polled/active drive
+assign DDRAM_ADDR     = drv_ddram_addr[arb_rr_state];
+assign DDRAM_DIN      = drv_ddram_din[arb_rr_state];
+assign DDRAM_BE       = drv_ddram_be[arb_rr_state];
+assign DDRAM_BURSTCNT = drv_ddram_burstcnt[arb_rr_state];
+
+// Only assert RD/WE if the bus isn't locked by an ongoing fetch
+assign DDRAM_RD = arb_is_locked ? 1'b0 : drv_ddram_rd[arb_rr_state];
+assign DDRAM_WE = arb_is_locked ? 1'b0 : drv_ddram_we[arb_rr_state];
+
+// BUSY Router: Drive must wait if it's not being polled, bus is locked, or RAM is busy
+generate
+	genvar arb_i;
+	for(arb_i=0; arb_i<NDR; arb_i=arb_i+1) begin : arb_routing_gen
+		// Force drive to wait if not polled, bus locked, or RAM busy
+		assign arb_ddram_busy[arb_i]  = (arb_rr_state != arb_i[1:0]) || arb_is_locked || DDRAM_BUSY;
+		// Only pass the ready pulse to the drive that currently owns the lock
+		assign arb_ddram_ready[arb_i] = (arb_rr_state == arb_i[1:0] && arb_is_locked) ? DDRAM_DOUT_READY : 1'b0;
+	end
+endgenerate
+
+// Polling and Burst-Lock FSM
+always @(posedge clk_sys) begin
+	if (&reset) begin
+		arb_is_locked   <= 1'b0;
+		arb_rr_state    <= 2'd0;
+		burst_remaining <= 8'd0;
+	end else begin
+		if (!arb_is_locked) begin
+			// POLLING: Check if the current drive wants the bus
+			if (!DDRAM_BUSY) begin
+				if (drv_ddram_rd[arb_rr_state]) begin
+					arb_is_locked   <= 1'b1; // Lock bus for the duration of the burst
+					burst_remaining <= drv_ddram_burstcnt[arb_rr_state];
+				end else if (!drv_ddram_we[arb_rr_state]) begin
+					// No request, move to next drive
+					arb_rr_state <= (arb_rr_state == N) ? 2'd0 : arb_rr_state + 2'd1;
+				end
+			end
+		end else begin
+			// LOCKED: Wait for the burst to complete
+			if (DDRAM_DOUT_READY) begin
+				if (burst_remaining <= 8'd1) begin
+					arb_is_locked <= 1'b0; // Unlock immediately
+					// Move to next drive to ensure fairness
+					arb_rr_state  <= (arb_rr_state == N) ? 2'd0 : arb_rr_state + 2'd1;
+				end else begin
+					burst_remaining <= burst_remaining - 8'd1;
+				end
+			end
+		end
+	end
+end
 
 endmodule

--- a/rtl/iec_drive/c1541_track.sv
+++ b/rtl/iec_drive/c1541_track.sv
@@ -1,4 +1,4 @@
-// 
+//
 // c1541_track
 // Copyright (c) 2016 Sorgelig
 //
@@ -15,14 +15,54 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
+// =============================================================================
+// DDRAM Background/Foreground FSM DMA Engine by Robin Wünderlich:
 //
-/////////////////////////////////////////////////////////////////////////
+// This module manages the high-speed transfer of floppy disk track data between
+// the DDRAM G64 image, the active drive emulation buffer, and the SD card.
+//
+// Image loading:
+//   - c64.cpp (ARM) loads complete G64 (or converted D64) images into DDRAM.
+//   - FGPA: Base addresses: 0x06000000 (Drive 8) and 0x06040000 (Drive 9).
+//	 - FGPA: 64bit index address   ARM: bytes address (=FPGA address *8)
+//
+// Foreground Tasks:
+//   - Track Change (Read): When the 1541 changes tracks, the FSM immediately
+//     bursts the requested track data from DDRAM directly into the BRAM track
+//     buffer inside the `direct_gcr` module (now 64 bit wide).
+//   - Track Save (Write): When the 1541 modifies a track, it triggers
+//     `save_track`. The FSM reads the modified track from the BRAM buffer and
+//     writes it back to the main image in DDRAM, marking the track as "dirty".
+//
+// Background Tasks (Flushing):
+//   - When the FSM is idle, it scans the `dirty_tracks` bitmask.
+//   - If a dirty track is found, the FSM burst copies the data from DDRAM into a
+//     dedicated local background BRAM buffer (`bg_buffer`).
+//   - It then signals the ARM/HPS (`sd_wr`, `sd_lba`) to stream that background
+//     buffer back to the physical .G64 file on the SD card. This ensures saves
+//     are non-blocking and do not stall the real-time C64 drive emulation.
+//	 - From a user perspective this is seamless and intuitive, he does not have
+//     to open the MiSTer menu in order to save.
+//
+// =============================================================================
+// Track Change/Loading Speed Comparison
+// =============================================================================
+// | Method                                             | Time       |
+// |----------------------------------------------------|------------|
+// | SD HPS_IO (miniz streaming from ZIP)               | ~ 8.90 ms  |
+// | SD HPS_IO (normal file)                            | ~ 4.30 ms  |
+// | SD HPS_IO (normal file, WIDE 16bit I/O)            | ~ 2.35 ms  |
+// | DDRAM DMA (Burst count = 1)                        | ~ 0.60 ms  |
+// | DDRAM DMA (Burst count = 32) (Current Method)      | ~ 0.03 ms  |
+// =============================================================================
+// Some timing sensitive disk protections fail at half-track changes > ~2.2ms
+///////////////////////////////////////////////////////////////////////////////
 
-module c1541_track
+module c1541_track #(parameter BURST_LEN = 32)
 (
 	input         clk,
 	input         reset,
-	
+
 	input         gcr_mode,
 
 	output [31:0] sd_lba,
@@ -34,11 +74,61 @@ module c1541_track
 	input         save_track,
 	input         change,
 	input   [6:0] track,
-	output reg    busy
+
+	output wire   busy_flushing,
+
+	input         drive_num,
+
+	// DDRAM Interface
+	input         DDRAM_BUSY,
+	output  [7:0] DDRAM_BURSTCNT,
+	output [28:0] DDRAM_ADDR,
+	input  [63:0] DDRAM_DOUT,
+	input         DDRAM_DOUT_READY,
+	output        DDRAM_RD,
+	output        DDRAM_WE,
+	output [63:0] DDRAM_DIN,
+	output  [7:0] DDRAM_BE,
+
+	// DMA Track Buffer Interface
+	output [13:0] dma_buff_addr,
+	output [63:0] dma_buff_dout,
+	output		  dma_buff_wr,
+	input  [63:0] dma_buff_din,
+
+	// Background Save Interface
+	input  [13:0] sd_buff_addr,
+	output [63:0] bg_buff_dout
 );
 
-assign sd_lba     = lba;
-assign sd_blk_cnt = gcr_mode ? 6'h1F : len[5:0];
+// -----------------------------------------------------------------------------
+// FSM State Definitions
+// -----------------------------------------------------------------------------
+
+// Dispatcher
+localparam IDLE                   = 4'd0;
+
+// DMA from DDRAM to track buffer (foreground)
+//                to bg buffer    (background)
+localparam REQ_OFFSET_RD          = 4'd1;
+localparam READ_OFFSET            = 4'd2;
+localparam START_DMA              = 4'd3;
+localparam REQ_BURST_RD           = 4'd4;
+localparam BURST_DDRAM_TO_BUFF    = 4'd5;
+localparam CHECK_DONE             = 4'd6;
+localparam GEN_DUMMY              = 4'd7;
+
+// DMA from track buffer to DDRAM
+localparam PREP_DDRAM_WRITE       = 4'd9;
+localparam WAIT_STATE_1_BUFF      = 4'd11;
+localparam WAIT_STATE_2_BUFF      = 4'd8;
+localparam READ_BUFF              = 4'd12;
+localparam WRITE_TO_DDRAM         = 4'd14;
+localparam FINISH_BEAT            = 4'd15;
+
+// -----------------------------------------------------------------------------
+// External Signal Synchronization
+// -----------------------------------------------------------------------------
 
 wire [6:0] track_s;
 wire       change_s, save_track_s, reset_s;
@@ -48,82 +138,372 @@ iecdrv_sync #(1) change_sync (clk, change,     change_s);
 iecdrv_sync #(1) save_sync   (clk, save_track, save_track_s);
 iecdrv_sync #(1) reset_sync  (clk, reset,      reset_s);
 
-wire [9:0] start_sectors[41] =
-'{  0, 21, 42, 63, 84,105,126,147,168,189,210,231,252,273,294,315,336,357,376,395,
-  414,433,452,471,490,508,526,544,562,580,598,615,632,649,666,683,700,717,734,751,
-  768
-};
+// -----------------------------------------------------------------------------
+// DDRAM Interface Logic
+// -----------------------------------------------------------------------------
+
+wire [28:0] ddr_base_addr_q = 29'h06000000 + (drive_num ? 29'h00040000 : 29'h0);
+reg  [28:0] ddr_offset_q;
+
+assign DDRAM_ADDR     = ddr_base_addr_q + ddr_offset_q;
+assign DDRAM_BURSTCNT = (dma_state == REQ_BURST_RD) ? dma_burst_len : 8'd1;
+assign DDRAM_RD       = (dma_state == REQ_OFFSET_RD) || (dma_state == REQ_BURST_RD);
+assign DDRAM_WE       = (dma_state == WRITE_TO_DDRAM);
+assign DDRAM_DIN      = dma_data_latch;
+assign DDRAM_BE       = (dma_state == WRITE_TO_DDRAM) ? be_mask : 8'hFF;
+
+// Combinatorial byte enable mask generation
+reg [7:0] be_mask;
+always @(*) begin
+	reg [3:0] end_byte;
+	reg [3:0] start_byte;
+
+	start_byte = (dma_ptr == 0 ) ? {1'b0, dma_align} : 4'd0;
+	end_byte   = (dma_last_sum) ? dma_last_sum : 4'd8;
+	be_mask    = 8'(((9'h01 << end_byte) - 9'h01) & ~((9'h01 << start_byte) - 9'h01));
+end
+
+// -----------------------------------------------------------------------------
+// ARM/SD Interface (Used for triggering SD-card write-back)
+// -----------------------------------------------------------------------------
 
 reg [31:0] lba;
-reg  [9:0] len;
+assign     sd_lba     = lba;
+assign     sd_blk_cnt = 6'd31; // (31+1) * 256 = 8192 bytes
+
+// -----------------------------------------------------------------------------
+// Internal DMA & Buffer Interface Logic
+// -----------------------------------------------------------------------------
+
+reg [63:0]  dma_data_latch;
+reg [63:0]  dma_prev_dout;
+reg [15:0]  dma_total_len;
+reg [13:0]  dma_ptr;
+reg [7:0]   dma_burst_count;
+reg [2:0]   dma_align;
+reg [3:0]   dma_state;
+reg [2:0]   dma_last_sum;
+reg         dma_first_q;
+
+
+reg [84:0]  dirty_tracks;
+reg [31:0]  bg_track_offset;
+reg [6:0]   bg_track;
+reg [6:0]   scan_track;
+reg         sd_state;
+reg         bg_state;
+
+
+assign dma_buff_dout = (dma_state == GEN_DUMMY) ? 64'd0 :
+                       (dma_align == 0) ? DDRAM_DOUT :
+                       ((DDRAM_DOUT << ((8 - dma_align) * 8)) | (dma_prev_dout >> (dma_align * 8)));
+wire   dma_bram_wr   = (dma_state == GEN_DUMMY) ? 1'b1 :
+                       (dma_state == BURST_DDRAM_TO_BUFF && DDRAM_DOUT_READY) ?
+                       ((dma_align == 0) ? 1'b1 : !dma_first_q) : 1'b0;
+
+wire [7:0]  dma_burst_len  = (bytes_left < 14'(BURST_LEN * 8)) ?
+                             8'(bytes_left >> 3) : 8'(BURST_LEN);
+wire [13:0] bytes_left     = 14'h2000 - dma_ptr;
+
+assign dma_buff_addr = dma_ptr;
+assign dma_buff_wr   = bg_state ? 1'b0 : dma_bram_wr;
+wire   bg_buff_wr    = bg_state ? dma_bram_wr : 1'b0;
+
+iecdrv_bitmem64SP #(10) bg_buffer
+(
+	.clock_a(clk),
+	.address_a(bg_state ? dma_ptr[12:3] : sd_buff_addr[12:3]),
+	.data_a(dma_buff_dout),
+	.wren_a(bg_buff_wr),
+	.q_a(bg_buff_dout)
+);
+
+// -----------------------------------------------------------------------------
+// Busy State Aggregation
+// -----------------------------------------------------------------------------
+
+assign busy_flushing = (|dirty_tracks) || sd_state || ((dma_state != IDLE) && bg_state);
+
+// -----------------------------------------------------------------------------
+// DMA Control FSM
+// -----------------------------------------------------------------------------
 
 always @(posedge clk) begin
-	reg  [6:0] cur_track = 0;
-	reg  [6:0] track_new;
-	reg        old_change, update = 0;
-	reg        saving = 0, initing = 0;
-	reg        old_save_track = 0;
-	reg        old_ack;
+    reg [31:0] cur_track_offset; // G64 image track offset in bytes
+	reg [6:0]  cur_track = 0;
+	reg [6:0]  track_new;
+	reg update     = 0;
+	reg old_change = 0;
+	reg old_save_track = 0;
+	reg old_ack = 0;
 
-	// delay track change after sync, so make sure save_track comes first.
-	track_new <= gcr_mode ? track_s : track_s[6:1];
+	track_new <= track_s;
 
 	old_change <= change_s;
-	if(~old_change & change_s) update <= 1;
-	
+	if(~old_change & change_s) begin
+		update <= 1;
+		dirty_tracks <= 0;
+	end
+
 	old_ack <= sd_ack;
 	if(sd_ack) {sd_rd,sd_wr} <= 0;
 
-	if(reset_s) begin
-		cur_track <= '1;
-		busy      <= 0;
+	if (reset_s) begin
+		dma_state <= IDLE;
+		sd_state  <= 0;
+		bg_state  <= 0;
+		cur_track <= '1; // out-of-band value, not yet initialized
+		update    <= 1;
+		dma_ptr   <= 0;
 		sd_rd     <= 0;
 		sd_wr     <= 0;
-		saving    <= 0;
-		update    <= 1;
-	end
-	else if(busy) begin
-		if(old_ack && ~sd_ack) begin
-			if((initing || saving) && (cur_track != track_new)) begin
-				saving    <= 0;
-				initing   <= 0;
-				cur_track <= track_new;
-				len       <= start_sectors[track_new+1'd1] - start_sectors[track_new] - 1'd1;
-				lba       <= gcr_mode ? track_new : start_sectors[track_new];
-				sd_rd     <= 1;
-			end
-			else begin
-				busy      <= 0;
-			end
-		end
-	end
-	else begin
 		old_save_track <= save_track_s;
-		if((old_save_track ^ save_track_s) && ~&cur_track[6:1]) begin
-			saving    <= 1;
-			len       <= start_sectors[cur_track+1'd1] - start_sectors[cur_track] - 1'd1;
-			lba       <= gcr_mode ? cur_track : start_sectors[cur_track];
-			sd_wr     <= 1;
-			busy      <= 1;
+		dirty_tracks   <= 0;
+		scan_track     <= 0;
+	end else begin
+		if (sd_state) begin
+			if(old_ack && ~sd_ack) begin
+				sd_state <= 0;
+			end
 		end
-		else if(update & ~gcr_mode) begin
-			update    <= 0;
-			initing   <= 1;
-			cur_track <= 17;
-			len       <= start_sectors[17+1] - start_sectors[17] - 1'd1;
-			lba       <= start_sectors[17];
-			sd_rd     <= 1;
-			busy      <= 1;
-		end
-		else if(cur_track != track_new || (update & gcr_mode)) begin
-			cur_track <= track_new;
-			len       <= start_sectors[track_new+1'd1] - start_sectors[track_new] - 1'd1;
-			lba       <= gcr_mode ? track_new : start_sectors[track_new];
-			sd_rd     <= 1;
-			busy      <= 1;
-			update    <= 0;
-		end
+
+		// =====================================================================
+		// Main DMA Control FSM
+		// =====================================================================
+		case (dma_state)
+
+			// --- Idle & Task Dispatcher ---
+			// Priority 1: Foreground Track Save (save_track toggled)
+			// Priority 2: Foreground Track Change (track_new updated or image mounted)
+			// Priority 3: Background SD Flush (dirty_tracks queue not empty)
+			IDLE: begin
+				if (old_save_track != save_track_s) begin
+					old_save_track <= save_track_s;
+					if (~&cur_track[6:1]) begin
+						// Don't save until cur_track initalized
+						// and don't save if no G64 offset
+						if (cur_track_offset != 0) begin
+							bg_state <= 0;
+							dma_state <= PREP_DDRAM_WRITE;
+						end
+					end
+				end else if ((cur_track != track_new) || update) begin
+					cur_track <= track_new;
+					update    <= 0;
+					dma_ptr   <= 0;
+					bg_state  <= 0;
+					// G64 header stores track offset table at $C
+					// Translate byte offset to quadword index
+					ddr_offset_q <= 29'((12 + track_new * 4) >> 3);
+					dma_state    <= REQ_OFFSET_RD;
+				end else if (dirty_tracks != 0 && sd_state == 0) begin
+					// Round-robin scan for the next dirty track to flush
+					if (dirty_tracks[scan_track]) begin
+						dirty_tracks[scan_track] <= 0;
+						bg_track     <= scan_track;
+						bg_state     <= 1;
+						dma_ptr      <= 0;
+						ddr_offset_q <= 29'((12 + scan_track * 4) >> 3);
+						dma_state    <= REQ_OFFSET_RD;
+					end
+					scan_track <= (scan_track >= 84) ? 7'd0 : scan_track + 1'd1;
+				end
+			end
+
+			// =================================================================
+			// DDRAM -> BRAM (FG Track Load / BG Fetch)
+			// =================================================================
+
+			// Fetch the 32-bit track offset pointer from the G64 header
+			REQ_OFFSET_RD: begin
+				if (!DDRAM_BUSY) dma_state <= READ_OFFSET;
+			end
+
+			READ_OFFSET: begin
+				if (DDRAM_DOUT_READY) begin
+					// The G64 header track offsets are 32-bit, but DDRAM_DOUT is 64-bit.
+					// Offsets are 4-byte aligned, so we just  pick the upper or lower half.
+					if (bg_state) begin
+						bg_track_offset  <= ((12 + bg_track * 4) & 4) ?
+										    DDRAM_DOUT[63:32] : DDRAM_DOUT[31:0];
+					end else begin
+						cur_track_offset <= ((12 + cur_track * 4) & 4) ?
+											DDRAM_DOUT[63:32] : DDRAM_DOUT[31:0];
+					end
+					dma_state <= START_DMA;
+				end
+			end
+
+			START_DMA: begin
+				dma_ptr <= 0;
+				if (bg_state) begin
+					if (bg_track_offset == 0) begin
+						dma_state <= GEN_DUMMY; // No track data, signal zero length to direct_gcr
+					end else begin
+						dma_align    <= bg_track_offset[2:0]; // Byte alignement (0-7)
+						ddr_offset_q <= 29'(bg_track_offset >> 3); // 64-bit Quadword index
+						dma_first_q  <= 1;
+						dma_state    <= REQ_BURST_RD;
+					end
+				end else begin
+					if (cur_track_offset == 0) begin
+						dma_state <= GEN_DUMMY;
+					end else begin
+						dma_align    <= cur_track_offset[2:0];
+						ddr_offset_q <= 29'(cur_track_offset >> 3);
+						dma_first_q  <= 1;
+						dma_state    <= REQ_BURST_RD;
+					end
+				end
+			end
+
+			REQ_BURST_RD: begin
+				if (!DDRAM_BUSY) begin
+					dma_state <= BURST_DDRAM_TO_BUFF;
+					dma_burst_count <= dma_burst_len - 1'd1;
+				end
+			end
+
+			// Because G64 track data rarely starts perfectly on a 64-bit boundary,
+			// we buffer the previous 64-bit word and bit-shift across the boundary
+			// using `dma_align` to construct a properly aligned word for the BRAM.
+			BURST_DDRAM_TO_BUFF: begin
+				if (DDRAM_DOUT_READY) begin
+					dma_burst_count <= dma_burst_count - 1'd1;
+					ddr_offset_q    <= ddr_offset_q + 1'd1;
+
+					if (dma_align == 0) begin // Perfectly aligned
+						dma_ptr <= dma_ptr + 4'd8;
+					end else begin               // Misaligned (Requires shifting)
+						dma_prev_dout <= DDRAM_DOUT; // Cache qword for shifting
+						if (dma_first_q) begin
+							dma_first_q <= 0;
+						end else begin
+							dma_ptr <= dma_ptr + 4'd8;
+						end
+					end
+
+					// Request the next burst chunk when finished
+					if (dma_burst_count == 0) begin
+						dma_state <= CHECK_DONE;
+					end
+				end
+			end
+
+			// Check if DDRAM to buffer DMA transfer is complete.
+			// If complete either return to idle (foreground transfer to track buffer),
+			// or trigger an SD card flush (background transfer to bg buffer)
+			CHECK_DONE: begin
+				if (dma_ptr >= 14'h2000) begin
+					if (bg_state) begin
+						dma_state <= IDLE;
+						bg_state <= 0;
+						// Safety Check: If the user mounted a new disk during dma,
+						// `update` will be 1, to not write to the new mount instead
+						// of the old, discard the data and do NOT trigger sd_wr
+						if (!update) begin
+							lba      <= {25'd0, bg_track};
+							sd_wr    <= 1;
+							sd_state <= 1;
+						end
+						dirty_tracks[bg_track] <= 0;
+					end else begin
+						dma_state <= IDLE;
+						dma_ptr   <= 0;
+						bg_state     <= 0;
+					end
+				end else begin
+					dma_state <= REQ_BURST_RD; // Keep bursting until 8KB is filled
+				end
+			end
+
+			// Writes eight dummy bytes of zeroes to the start of the buffer,
+			// signalling to direct_gcr, that no track data is available.
+			// G64 tracks start with a two byte length indicator, followed by data.
+			// The direct_gcr module creates virtual tracks on-the-fly for all
+			// tracks with length < d6000
+			GEN_DUMMY: begin
+					dma_state <= IDLE;
+					bg_state <= 0;
+			end
+
+			// =================================================================
+			// BRAM -> DDRAM (Track Flush to Memory)
+			// =================================================================
+
+			PREP_DDRAM_WRITE: begin
+				ddr_offset_q       <= 29'(cur_track_offset >> 3);
+				dma_align          <= cur_track_offset[2:0];
+				dma_last_sum       <= 0;
+				dma_total_len      <= '1; // out-of-band value
+				dma_ptr            <= 0;
+				dma_data_latch     <= 0;
+				dma_prev_dout      <= 0;
+				dma_state          <= WAIT_STATE_1_BUFF;
+			end
+
+			// BRAM has a 2-cycle read latency
+			WAIT_STATE_1_BUFF: begin
+				dma_state <= WAIT_STATE_2_BUFF;
+			end
+
+			WAIT_STATE_2_BUFF: begin
+				dma_state <= READ_BUFF;
+			end
+
+			READ_BUFF: begin
+				// The first 2 bytes of track BRAM indicate track length in bytes.
+				// The 2 byte header is directly followed by the gcr data payload.
+				// So in total we transfer track length + 2 bytes.
+				// We abort transfer of invalid sized tracks
+				if (dma_ptr == 0 && dma_buff_din[15:0] <= 16'd8) begin
+					dma_state <= IDLE; // Abort
+				end else begin
+					if (dma_ptr == 0) begin
+						dma_total_len <= ((dma_buff_din[15:0] > 16'd8190) ?
+										 16'd8192 : dma_buff_din[15:0] + 16'd2);
+					end
+
+					// Bit-shift the 64-bit BRAM word across the boundary so it cleanly
+					// aligns with the target DDRAM memory offset.
+					if (dma_align == 0) begin
+						dma_data_latch <= dma_buff_din;
+					end else begin
+						dma_data_latch <= (dma_buff_din << (dma_align * 8)) |
+										  (dma_prev_dout >> ((8 - dma_align) * 8));
+					end
+					dma_prev_dout <= dma_buff_din;
+
+					// Set dma_last_sum on final write to adjust be_mask end_byte
+					// dma_total_len initialized so that condition can't trigger
+					// on first Q
+					if ((dma_ptr + (16'd8 - {13'd0, dma_align})) >= dma_total_len) begin
+						dma_last_sum <= 3'(dma_align + dma_total_len[2:0]);
+					end
+				dma_state <= WRITE_TO_DDRAM;
+				end
+
+			end
+
+			WRITE_TO_DDRAM: begin
+				if (!DDRAM_BUSY) begin
+					// Advance DDR offset and BRAM pointer
+					ddr_offset_q <= ddr_offset_q + 1'd1;
+					dma_ptr      <= dma_ptr + 4'd8;
+					// Check if we reached the end of the track using the CURRENT dma_ptr
+					if (dma_ptr + (16'd8 - {13'd0, dma_align}) >= dma_total_len) begin
+						dma_state <= IDLE;
+						// Mark track as dirty so the background FSM will flush it to SD later
+						if (!update) dirty_tracks[cur_track] <= 1'b1;
+					end else begin
+						// Loop back to fetch the next word from BRAM
+						dma_state <= WAIT_STATE_1_BUFF;
+					end
+				end
+			end
+
+		endcase
 	end
-end
+	end
 
 endmodule

--- a/rtl/iec_drive/iec_drive.sv
+++ b/rtl/iec_drive/iec_drive.sv
@@ -18,14 +18,16 @@ module iec_drive #(parameter PARPORT=1,DUALROM=1,DRIVES=2)
 	input         img_readonly,
 	input  [31:0] img_size,
 	
-	// 00 - 1541 emulated GCR(D64)
 	// 01 - 1541 real GCR mode (G64,D64)
 	// 10 - 1581 (D81)
+	// 00 - Unused (formerly 1541 emulated GCR D64)
 	input   [1:0] img_type,
 	input   [2:0] drive_rpm,
 	input         drive_wobble,
 
 	output  [N:0] led,
+	output wire [6:0] out_track[NDR],
+	output wire [N:0] out_we,
 	output        disk_ready,
 
 	input         iec_atn_i,
@@ -56,8 +58,18 @@ module iec_drive #(parameter PARPORT=1,DUALROM=1,DRIVES=2)
 	input  [15:0] rom_addr,
 	input   [7:0] rom_data,
 	input         rom_wr,
-	input         rom_std
-);
+	input         rom_std,
+
+	input         DDRAM_BUSY,
+	output  [7:0] DDRAM_BURSTCNT,
+	output [28:0] DDRAM_ADDR,
+	input  [63:0] DDRAM_DOUT,
+	input         DDRAM_DOUT_READY,
+	output        DDRAM_RD,
+	output        DDRAM_WE,
+	output [63:0] DDRAM_DIN,
+	output  [7:0] DDRAM_BE
+	);
 
 localparam NDR = (DRIVES < 1) ? 1 : (DRIVES > 4) ? 4 : DRIVES;
 localparam N   = NDR - 1;
@@ -102,6 +114,8 @@ c1541_multi #(.PARPORT(PARPORT), .DUALROM(DUALROM), .DRIVES(DRIVES)) c1541
 	.iec_clk_o (c1541_iec_clk),
 
 	.led(c1541_led),
+	.out_track(out_track),
+	.out_we(out_we),
 	.disk_ready(disk_ready),
 
 	.par_data_i(par_data_i),
@@ -131,8 +145,18 @@ c1541_multi #(.PARPORT(PARPORT), .DUALROM(DUALROM), .DRIVES(DRIVES)) c1541
 	.sd_buff_addr(sd_buff_addr),
 	.sd_buff_dout(sd_buff_dout),
 	.sd_buff_din(c1541_sd_buff_dout),
-	.sd_buff_wr(sd_buff_wr)
-);
+	.sd_buff_wr(sd_buff_wr),
+
+	.DDRAM_BUSY(DDRAM_BUSY),
+	.DDRAM_BURSTCNT(DDRAM_BURSTCNT),
+	.DDRAM_ADDR(DDRAM_ADDR),
+	.DDRAM_DOUT(DDRAM_DOUT),
+	.DDRAM_DOUT_READY(DDRAM_DOUT_READY),
+	.DDRAM_RD(DDRAM_RD),
+	.DDRAM_WE(DDRAM_WE),
+	.DDRAM_DIN(DDRAM_DIN),
+	.DDRAM_BE(DDRAM_BE)
+	);
 
 
 wire        c1581_iec_data, c1581_iec_clk, c1581_stb_o;

--- a/rtl/iec_drive/iecdrv_misc.sv
+++ b/rtl/iec_drive/iecdrv_misc.sv
@@ -122,3 +122,115 @@ always @(posedge clock_b) begin
 end
 
 endmodule
+
+module iecdrv_bitmem64 #(parameter ADDRWIDTH)
+(
+	input	                     clock_a,
+	input	     [ADDRWIDTH-1:0] address_a,
+	input	              [63:0] data_a,
+	input	                     wren_a,
+	output wire          [63:0] q_a,
+
+	input	                     clock_b,
+	input	     [ADDRWIDTH+5:0] address_b,
+	input	                     data_b,
+	input	                     wren_b,
+	output wire                 q_b
+);
+
+wire [7:0] q_a_bytes[8];
+wire q_b_bits[8];
+
+genvar i;
+generate
+	for(i=0; i<8; i=i+1) begin : rams
+		iecdrv_bitmem #(ADDRWIDTH) bitmem (
+			.clock_a(clock_a),
+			.address_a(address_a),
+			.data_a(data_a[i*8 +: 8]),
+			.wren_a(wren_a),
+			.q_a(q_a_bytes[i]),
+
+			.clock_b(clock_b),
+			.address_b({address_b[ADDRWIDTH+5:6], address_b[2:0]}),
+			.data_b(data_b),
+			.wren_b(wren_b & (address_b[5:3] == i[2:0])),
+			.q_b(q_b_bits[i])
+		);
+	end
+endgenerate
+
+assign q_a = {q_a_bytes[7], q_a_bytes[6], q_a_bytes[5], q_a_bytes[4],
+              q_a_bytes[3], q_a_bytes[2], q_a_bytes[1], q_a_bytes[0]};
+
+reg [2:0] b_sel_d, b_sel_d2;
+always @(posedge clock_b) begin
+	b_sel_d <= address_b[5:3];
+	b_sel_d2 <= b_sel_d;
+end
+
+assign q_b = q_b_bits[b_sel_d2];
+
+endmodule
+
+// -------------------------------------------------------------------------------
+
+module iecdrv_bitmemSP #(parameter ADDRWIDTH)
+(
+	input	                     clock_a,
+	input	     [ADDRWIDTH-1:0] address_a,
+	input	               [7:0] data_a,
+	input	                     wren_a,
+	output reg           [7:0] q_a
+);
+
+reg [7:0] ram[1<<ADDRWIDTH];
+
+reg                 wren_a_d;
+reg [ADDRWIDTH-1:0] address_a_d;
+reg           [7:0] data_a_d;
+always @(posedge clock_a) begin
+	wren_a_d    <= wren_a;
+	address_a_d <= address_a;
+	data_a_d    <= data_a;
+end
+
+always @(posedge clock_a) begin
+	if(wren_a_d) begin
+		ram[address_a_d] <= data_a_d;
+		q_a <= data_a_d;
+	end else begin
+		q_a <= ram[address_a_d];
+	end
+end
+
+endmodule
+
+module iecdrv_bitmem64SP #(parameter ADDRWIDTH)
+(
+	input	                     clock_a,
+	input	     [ADDRWIDTH-1:0] address_a,
+	input	              [63:0] data_a,
+	input	                     wren_a,
+	output wire          [63:0] q_a
+);
+
+wire [7:0] q_a_bytes[8];
+
+genvar i;
+generate
+	for(i=0; i<8; i=i+1) begin : rams
+		iecdrv_bitmemSP #(ADDRWIDTH) bitmem (
+			.clock_a(clock_a),
+			.address_a(address_a),
+			.data_a(data_a[i*8 +: 8]),
+			.wren_a(wren_a),
+			.q_a(q_a_bytes[i])
+		);
+	end
+endgenerate
+
+assign q_a = {q_a_bytes[7], q_a_bytes[6], q_a_bytes[5], q_a_bytes[4],
+              q_a_bytes[3], q_a_bytes[2], q_a_bytes[1], q_a_bytes[0]};
+
+endmodule

--- a/rtl/iec_drive/lfsr.v
+++ b/rtl/iec_drive/lfsr.v
@@ -1,10 +1,18 @@
-module random (
-   input clock,
-   output reg [30:0] lfsr
+module random_xor (
+	input clock,
+	input reset,
+	input [31:0] seed,
+	output reg [31:0] lfsr
 );
 
 always @(posedge clock) begin
-  lfsr <= {lfsr[29:0], lfsr[30] ^~ lfsr[27]};
+	if (reset) begin
+		// initialize with non-zero seed
+		lfsr <= (seed != 0) ? seed : 32'h1234abcd;
+	end else begin
+		lfsr <=  ((lfsr ^ (lfsr << 13)) ^ ((lfsr ^ (lfsr << 13)) >> 17)) ^
+		        (((lfsr ^ (lfsr << 13)) ^ ((lfsr ^ (lfsr << 13)) >> 17)) << 5);
+		end
 end
 
 endmodule


### PR DESCRIPTION
This update introduces full DDRAM loading for G64 and D64 images (needs new MiSTer Main), managed by a custom DDRAM Background/Foreground FSM DMA Engine and a drive OSD.

   * Full DDRAM Image Loading & DMA Engine (c1541_track.sv)
     * Complete G64/D64 images are now loaded entirely into DDRAM (Base addresses: 0x06000000 for Drive 8, 0x06040000 for Drive 9).
     * Foreground Tasks (Instant Track Change): When the 1541 changes tracks, the FSM instantly bursts the requested track data from DDRAM into a new 64-bit wide BRAM buffer (direct_gcr). Track loading times have dropped from ~8.90ms (using miniz streaming from zip over SD HPS_IO) to ~0.03ms (DDRAM DMA Burst = 32). This resolves failures in highly timing-sensitive disk protections that break when half-track changes exceed ~2.2ms (e.g. Defender of the Crown S2 Tournament check). It also fixes #190 . 
     * Background Tasks: Saves are now completely non-blocking. A C1541 writes are handled by a non-blocking DMA transfer into DDRAM where the track is marked dirty.  When idle, the FSM scans a dirty_tracks bitmask, bursts the dirty track to a background buffer, and signals the ARM/HPS to stream it to the SD card..
     * Track buffer read-outs trigger on a Write->Read transition timeout (if the drive remains in read mode for ~500ms since the last write), or immediately if the motor turns off. This avoids disk corruption with some extremely ill-behaved copiers that rapidly toggle activity LED and keep the motor on during disk swaps.
     * DDRAM Round-Robin Arbiter (c1541_multi.sv) manages memory access across multiple drives,
       supporting read bursts and back-to-back writing.
   * Drive OSD (drv_overlay.sv)
     * Configurable via the drives menu: Activity Only, If Mounted, Debug, and Off.
     * Provides color-coded feedback: Green (idle), Yellow (read), Red (write/background flush).
     * Displays the track number including half tracks (e.g., 33.5).
     * 3-stage pipelined design to minimise combinatorial load.
     * Optional Debug Mode: Snoops real-time DDRAM reads/writes, featuring a rolling buffer and a base-address watcher. The base address can be adjusted on the fly using keyboard cursor keys with timed auto-repeat. (This was extremely useful during development, but can be removed later if no longer needed)
     
   * Additional Fixes & Additions
     * Added auto reset when toggling pal/ntsc and a 50ms pulse to close the OSD during PAL/NTSC switching (c64.sv), preventing the screen from (sometimes) hanging black if "Pause when OSD is opened" is enabled.
     * Extended iecdrv_misc.sv with iecdrv_bitmem64 and iecdrv_bitmem64SP to support the new 64-bit wide buffers.
     * Updated README.md to document new features, and some other (hopeful) useful info for users
     * also fixes #198 