### PR TITLE
Fix: Keyboard dropping keystrokes.

### DIFF
--- a/rtl/fpga64_keyboard.vhd
+++ b/rtl/fpga64_keyboard.vhd
@@ -158,6 +158,13 @@ architecture rtl of fpga64_keyboard is
 	signal ps2_stb   : std_logic;
 	signal key_8s    : std_logic := '0';
 
+	-- Used to remap shift + number:
+	signal phys_6: std_logic := '0';
+	signal phys_7: std_logic := '0';
+	signal phys_8: std_logic := '0';
+	signal phys_9: std_logic := '0';
+	signal phys_0: std_logic := '0';
+
 begin
 
 	delay_end <= '1' when delay_cnt = 0 else '0';
@@ -377,24 +384,19 @@ begin
 					when X"33" => key_H <= pressed; 
 					when X"34" => key_G <= pressed; 
 					when X"35" => key_Y <= pressed; 
-					when X"36" => key_7 <= pressed and     key_shift;
-									  key_6 <= pressed and not key_shift;
+					when X"36" => phys_6 <= pressed;
 					when X"3A" => key_M <= pressed; 
 					when X"3B" => key_J <= pressed; 
 					when X"3C" => key_U <= pressed; 
-					when X"3D" => key_6 <= pressed and     key_shift;
-									  key_7 <= pressed and not key_shift;
-					when X"3E" => key_8s <= pressed and    key_shift;
-									  key_8 <= pressed and not key_shift;
+					when X"3D" => phys_7 <= pressed;
+					when X"3E" => phys_8 <= pressed;
 									  delay_cnt <= 300000;
 					when X"41" => key_comma <= pressed; 
 					when X"42" => key_K <= pressed;
 					when X"43" => key_I <= pressed; 
 					when X"44" => key_O <= pressed; 
-					when X"45" => key_9 <= pressed and     key_shift;
-									  key_0 <= pressed and not key_shift;
-					when X"46" => key_8 <= pressed and     key_shift;
-									  key_9 <= pressed and not key_shift;
+					when X"45" => phys_0 <= pressed;
+					when X"46" => phys_9 <= pressed;
 					when X"49" => key_dot <= pressed; 
 					when X"4A" => key_slash <= pressed; 
 					when X"4B" => key_L <= pressed; 
@@ -430,6 +432,19 @@ begin
 				end case;
 			end if;
 			
+			-- Remap without dropping keystrokes:
+			-- shift-7 to shift-6
+			key_6  <= (phys_6 and not key_shift) or (phys_7 and key_shift);
+			-- shift-6 to shift-7
+			key_7  <= (phys_7 and not key_shift) or (phys_6 and key_shift);
+			-- shift-8 to * (uses delay_cnt so shift is suppressed for * register)
+			key_8s <=  phys_8 and key_shift;
+			-- shift 9 to shift-8
+			key_8  <= (phys_8 and not key_shift) or (phys_9 and key_shift);
+			-- shift-0 to shift-9
+		    key_9  <= (phys_9 and not key_shift) or (phys_0 and key_shift);
+			key_0  <=  phys_0 and not key_shift;
+
 			if reset = '1' then
 					key_F1        <= '0';
 					key_F2        <= '0';
@@ -482,6 +497,11 @@ begin
 					key_8s        <= '0';
 					key_9         <= '0';
 					key_0         <= '0';
+					phys_6        <= '0';
+					phys_7        <= '0';
+					phys_8        <= '0';
+					phys_9        <= '0';
+					phys_0        <= '0';
 					key_Q         <= '0'; 
 					key_Z         <= '0'; 
 					key_S         <= '0'; 


### PR DESCRIPTION
The Problem: Previously, multiple physical keys were driving the same C64 keys to handle shift-mapping (e.g., mapping shift-0 to C64 shift-9).

Example  (Prior to fix):
   1. Hold 0 (Scancode X"45"): Logical key_0 is set to 1.
   2. Additionally hold 9 (Scancode X"46"): Logical key_9 is set to 1. (Both are pressed).
   3. Release 0: The release event for 0 triggers key_0 <= 0, but because of the flawed shift-mapping logic, it also triggers key_9  <= 0, even though physical 9 is still held down. 
   4. The C64 only registers one "0", but normal expected result (real C64 and all other keys) is "09"

The Fix decouples the few shift mapped keys:
   1. Physical Keys: New intermediate signals (phys_0, phys_9, etc.) independently track the physical state of
      these keys. Releasing 0 now only updates phys_0.
   2. Shift-Mapping: Outside the event handler, the logical keys continuously evaluate their state based on the
      physical keys and the shift modifier (e.g., key_9 <= (phys_9 and not key_shift) or (phys_0 and key_shift)).

Now, releasing 0 no longer interferes with the state of 9, resulting in the expected 09 being typed. The same issue was also present for the other shift-mapped keys and is fixed now. Fixes  #178 