### PR TITLE
Hook up 1581 to OSD

### DIFF
--- a/c64.sv
+++ b/c64.sv
@@ -1039,7 +1039,7 @@ wire       drive_iec_data_o;
 wire       drive_reset = ~reset_n | status[6] | (load_c1581 & ioctl_download);
 
 wire [1:0] drive_led;
-wire [6:0] drive_track[2];
+wire [7:0] drive_track[2];
 wire [1:0] drive_we;
 wire       disk_ready;
 

--- a/rtl/drv_overlay.sv
+++ b/rtl/drv_overlay.sv
@@ -263,8 +263,8 @@ wire valid_pixel_rd = dbg_area && active_row && debug_active && (dbg_px < 5) && 
 wire valid_pixel_wr = dbg_area && active_row && debug_active && (dbg_px < 5) && (dbg_py < 5) && (dbg_col >= 26) && (dbg_col < 51) && (dbg_col != 34);
 
 reg [4:0]  drv_char;
-wire [6:0] drv_track  = drv_row ? drive_track_1 : drive_track_0;
-wire [6:0] full_track = (drv_track >> 1) + 7'd1;
+wire [7:0] drv_track  = drv_row ? drive_track_1 : drive_track_0;
+wire [7:0] full_track = (drv_track >> 1) + 8'd1;
 wire       half_track = drv_track[0];
 
 wire [3:0] track_tens = (full_track >= 80) ? 4'd8 : (full_track >= 70) ? 4'd7 : (full_track >= 60) ? 4'd6 :

--- a/rtl/iec_drive/c1581_drv.sv
+++ b/rtl/iec_drive/c1581_drv.sv
@@ -25,6 +25,9 @@ module c1581_drv
 	input   [1:0] drive_num,
 	output        act_led,
 	output        pwr_led,
+	// OSD
+	output  [7:0] track,
+	output        we,
 
 	input         iec_atn_i,
 	input         iec_data_i,
@@ -253,6 +256,7 @@ fdc1772 #(.IMG_TYPE(1), .EXT_MOTOR(1), .FD_NUM(1)) fdc
 
 	.img_mounted(img_mounted),
 	.img_size(img_size),
+
 	.sd_lba(sd_lba),
 	.sd_rd(sd_rd),
 	.sd_wr(sd_wr),
@@ -260,7 +264,10 @@ fdc1772 #(.IMG_TYPE(1), .EXT_MOTOR(1), .FD_NUM(1)) fdc
 	.sd_buff_addr(sd_buff_addr),
 	.sd_dout(sd_buff_dout),
 	.sd_din(sd_buff_din),
-	.sd_dout_strobe(sd_buff_wr)
+	.sd_dout_strobe(sd_buff_wr),
+
+	.track_out(track),
+	.we_out(we)
 );
 
 endmodule

--- a/rtl/iec_drive/c1581_multi.sv
+++ b/rtl/iec_drive/c1581_multi.sv
@@ -23,6 +23,9 @@ module c1581_multi #(parameter PARPORT=1,DUALROM=1,DRIVES=2)
 
 	output  [N:0] act_led,
 	output  [N:0] pwr_led,
+	// OSD
+	output wire [7:0] out_track[NDR],
+	output wire [N:0] out_we,
 
 	input         iec_atn_i,
 	input         iec_data_i,
@@ -160,6 +163,14 @@ wire [N:0] act_led_drv, pwr_led_drv;
 assign     act_led = act_led_drv & ~reset_drv;
 assign     pwr_led = pwr_led_drv & ~reset_drv;
 
+wire [7:0] track_drv[NDR];
+wire       we_drv[NDR];
+
+always_comb for(int j=0; j<NDR; j=j+1) begin
+	out_track[j] = track_drv[j] << 1;
+	out_we[j]    = we_drv[j];
+end
+
 generate
 	genvar i;
 	for(i=0; i<NDR; i=i+1) begin :drives
@@ -180,6 +191,8 @@ generate
 			.drive_num(i),
 			.act_led(act_led_drv[i]),
 			.pwr_led(pwr_led_drv[i]),
+			.track(track_drv[i]),
+			.we(we_drv[i]),
 
 			.iec_atn_i(iec_atn),
 			.iec_data_i(iec_data & iec_data_o),
@@ -212,3 +225,4 @@ generate
 endgenerate
 
 endmodule
+

--- a/rtl/iec_drive/fdc1772.v
+++ b/rtl/iec_drive/fdc1772.v
@@ -55,8 +55,13 @@ module fdc1772 (
 	input      [8:0] sd_buff_addr,
 	input      [7:0] sd_dout,
 	output     [7:0] sd_din,
-	input            sd_dout_strobe
+	input            sd_dout_strobe,
+	output     [7:0] track_out,   // track for OSD
+	output           we_out       // we for OSD
 );
+
+assign track_out = track;
+assign we_out = ((cmd[7:5] == 3'b101 || cmd[7:4] == 4'b1111) && busy) || (sd_state == SD_WRITE);
 
 
 parameter CLK_EN           = 16'd8000; // in kHz

--- a/rtl/iec_drive/iec_drive.sv
+++ b/rtl/iec_drive/iec_drive.sv
@@ -26,7 +26,7 @@ module iec_drive #(parameter PARPORT=1,DUALROM=1,DRIVES=2)
 	input         drive_wobble,
 
 	output  [N:0] led,
-	output wire [6:0] out_track[NDR],
+	output wire [7:0] out_track[NDR],
 	output wire [N:0] out_we,
 	output        disk_ready,
 
@@ -94,10 +94,20 @@ end
 wire        c1541_iec_data, c1541_iec_clk, c1541_stb_o;
 wire  [7:0] c1541_par_o;
 wire  [N:0] c1541_led;
+wire  [6:0] c1541_out_track[NDR];
+wire  [N:0] c1541_out_we;
 wire  [7:0] c1541_sd_buff_dout[NDR];
 wire [31:0] c1541_sd_lba[NDR];
 wire  [N:0] c1541_sd_rd, c1541_sd_wr;
 wire  [5:0] c1541_sd_blk_cnt[NDR];
+
+wire  [7:0] c1581_out_track[NDR];
+wire  [N:0] c1581_out_we;
+
+always_comb for(int i=0; i<NDR; i=i+1) begin
+	out_track[i] = dtype[1][i] ? c1581_out_track[i] : {1'b0, c1541_out_track[i]};
+	out_we[i]    = dtype[1][i] ? c1581_out_we[i]    : c1541_out_we[i];
+end
 
 c1541_multi #(.PARPORT(PARPORT), .DUALROM(DUALROM), .DRIVES(DRIVES)) c1541
 (
@@ -114,8 +124,8 @@ c1541_multi #(.PARPORT(PARPORT), .DUALROM(DUALROM), .DRIVES(DRIVES)) c1541
 	.iec_clk_o (c1541_iec_clk),
 
 	.led(c1541_led),
-	.out_track(out_track),
-	.out_we(out_we),
+	.out_track(c1541_out_track),
+	.out_we(c1541_out_we),
 	.disk_ready(disk_ready),
 
 	.par_data_i(par_data_i),
@@ -180,6 +190,8 @@ c1581_multi #(.PARPORT(PARPORT), .DUALROM(DUALROM), .DRIVES(DRIVES)) c1581
 	.iec_clk_o (c1581_iec_clk),
 
 	.act_led(c1581_led),
+	.out_track(c1581_out_track),
+	.out_we(c1581_out_we),
 
 	.par_data_i(par_data_i),
 	.par_stb_i(par_stb_i),


### PR DESCRIPTION
Hooks up the 1581 to the drive OSD:
 - just exposes track and write signal to OSD
 
This completes the drive overhaul, so from my perspective there is not much in the way of going stable soon. Most remaining issues are feature request, and besides some minor SID and VIC glitches only two problems with CRTs  (BMP-DATA TURBO 2000) remain.