### PR TITLE
C64 with extended C1530 functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ Based on FPGA64 by Peter Wendrich with heavy later modifications by different pe
 - Pause option when OSD is opened
 - 4 joysticks mode
 - Snac DB9 joysticks support (via UserIO)
+- Autofire with 2 different speed on DB9 Snac joysticks 
 - RS232 with VIC-1011 and UP9600 modes either internal or through USER_IO
 - Loadable Kernal/C1541 ROMs
 - Special reduced border mode for 16:9 display
 - C128/Smart Turbo mode up to 4x
 - Real-time clock
 - Drive OSD showing mount status, read/write activity and current track
+- Complete C1530 Datasette implementation with on screen Counter and shortcuts keys
 
 ## Installation
 Copy the *.rbf to the root of the SD card. Copy disks/carts to C64 folder.
@@ -32,13 +34,17 @@ Copy the *.rbf to the root of the SD card. Copy disks/carts to C64 folder.
 ### Keyboard
 Note: F2, F4, F6, F8, Left/Up keys automatically activate Shift key.
 
-| Key       | Function                                     |
-|:---------:|----------------------------------------------|
-| F9        | Arrow-up key                                 |
-| F10       | = key                                        |
-| F11       | Restore key. Also special key in AR/FC carts |
-| Alt, Tab  | C= key                                       |
-| PgUp      | Tape play/pause                              |
+| Key                   | Function                                     |
+|:---------------------:|----------------------------------------------|
+| F9                    | Arrow-up key                                 |
+| F10                   | = key                                        |
+| F11                   | Restore key. Also special key in AR/FC carts |
+| Alt, Tab              | C= key                                       |
+| CTRL + Cursor Up      | Tape Play / Stop                             |
+| CTRL + Cursor Down    | Tape Stop                                    |
+| CTRL + Cursor Left    | Tape Rewind                                  |
+| CTRL + Cursor Right   | Tape Fast Forward                            |
+| CTRL + Canc (or Del)  | Tape Counter Reset                           |
 <br>
 
 ![keyboard-mapping](https://github.com/mister-devel/C64_MiSTer/blob/master/keymap.gif)
@@ -76,6 +82,9 @@ For **C1581** you can use separate ROM with size up to 32768 bytes.
 
 ### Autoload the cartridge
 In OSD->Hardware page you can choose Boot Cartridge, so every time a core is loaded, this cartridge will be loaded too.
+
+### C1530 and tape support
+In OSD->Load *.TAP and choose a TAP file. When a TAP is mounted, on OSD all the commands for managing the C1530 will appear and the keyboard shortcuts will also be enabled. For show counter on display (HDMI and CRT), enable Tape Counter on OSD and save settings. 
 
 ### Parallel port
 Are you tired of long loading times and fast loaders aren't really fast when comparing to other systems? 

--- a/c64.sv
+++ b/c64.sv
@@ -63,7 +63,20 @@ assign HDMI_BOB_DEINT = 0;
 //
 // 6     7         8         9         10        11        12
 // 45678901234567890123456789012345 67890123456789012345678901234567
-// XXXXXXXXXXXXXXXXXXXXX
+// XXXXXXXXXXXXXXXXXXXXXXXXXXX  XXXX
+//                            ^^^^^ 91=Tape Counter Reset, 92=Tape Counter On/Off,
+//                                  93=Tape Rewind, 94=Tape Fast Forward, 95=Tape Stop
+//
+// Tape-related status bits:
+//   7  = Tape Play/Pause
+//   11 = Tape Sound
+//   23 = Tape Unload
+//   39 = Tape Autoplay
+//   91 = Tape Counter Reset
+//   92 = Tape Counter On/Off
+//   93 = Tape Rewind
+//   94 = Tape Fast Forward
+//   95 = Tape Stop
 
 `include "build_id.v"
 localparam CONF_STR = {
@@ -77,6 +90,11 @@ localparam CONF_STR = {
 	"hAO[62],Autosave,Off,On;",
 	"h3-;",
 	"h3R[7],Tape Play/Pause;",
+	"h3R[95],Tape Stop;",
+	"h3R[93],Tape Rewind;",
+	"h3R[94],Tape Fast Forward;",
+	"h3O[92],Tape Counter,Off,On;",
+	"h3R[91],Tape Counter Reset;",
 	"h3R[23],Tape Unload;",
 	"h3O[11],Tape Sound,Off,On;",
 	"-;",
@@ -148,6 +166,7 @@ localparam CONF_STR = {
 	"-;",
 	"O[3],Swap Joysticks,No,Yes;",
 	"O[88:87],SNAC Joystick,Disabled,Joy 1,Joy 2;",
+	"O[90:89],SNAC Autofire,Off,Slow,Fast;",
 	"-;",
 	"O[47:46],Turbo mode,Off,C128,Smart;",
 	"d6O[49:48],Turbo speed,2x,3x,4x;",
@@ -318,6 +337,7 @@ wire  [7:0] ioctl_din;
 wire  [7:0] ioctl_index;
 wire        ioctl_download;
 wire        ioctl_upload;
+wire        tap_scanner_wait;
 wire [31:0] ioctl_file_ext;
 
 wire [31:0] sd_lba[2];
@@ -392,7 +412,7 @@ hps_io #(.CONF_STR(CONF_STR), .VDNUM(2), .BLKSZ(1)) hps_io
 	.ioctl_upload(ioctl_upload),
 	.ioctl_din(ioctl_din),
 	.ioctl_rd(ioctl_rd),
-	.ioctl_wait(ioctl_req_wr|ioctl_req_rd|reset_wait)
+	.ioctl_wait(ioctl_req_wr|ioctl_req_rd|reset_wait|((ioctl_index == 'hC1) & tap_scanner_wait))
 );
 
 wire load_prg   = ioctl_index == 'h01;
@@ -540,7 +560,6 @@ wire [6:0] joyB_int = joy[8] ? 7'd0 : {joyB[6:4], joyB[0], joyB[1], joyB[2], joy
 wire [6:0] joyC_c64 = joy[8] ? 7'd0 : {joyC[6:4], joyC[0], joyC[1], joyC[2], joyC[3]};
 wire [6:0] joyD_c64 = joy[8] ? 7'd0 : {joyD[6:4], joyD[0], joyD[1], joyD[2], joyD[3]};
 
-// swap joysticks if requested
 // SNAC DB9 joystick support - C64/Amiga/SMS standard pinout:
 //   Pin 1 Up     -> USER_IN[1]  (active low)
 //   Pin 2 Down   -> USER_IN[0]  (active low)
@@ -550,12 +569,23 @@ wire [6:0] joyD_c64 = joy[8] ? 7'd0 : {joyD[6:4], joyD[0], joyD[1], joyD[2], joy
 //   Pin 6 Fire A -> USER_IN[2]  (active low, Button 1)
 //   Pin 9 Fire B -> USER_IN[6]  (active low, Button 2)
 wire [1:0] snac_mode = status[88:87]; // 0=disabled, 1=Joy1, 2=Joy2
-wire [6:0] snac_joy  = {1'b0, ~USER_IN[6], ~USER_IN[2],
-                        ~USER_IN[3], ~USER_IN[5], ~USER_IN[0], ~USER_IN[1]};
+wire [6:0] snac_joy  = {1'b0, ~USER_IN[6], ~USER_IN[2], ~USER_IN[3], ~USER_IN[5], ~USER_IN[0], ~USER_IN[1]};
+
 // format: {fire3=0, fireB(Pin9), fireA(Pin6), right(Pin4), left(Pin3), down(Pin2), up(Pin1)}
 
-wire [6:0] joyA_c64 = (snac_mode == 2'd1) ? snac_joy : (status[3] ? joyB_int : joyA_int);
-wire [6:0] joyB_c64 = (snac_mode == 2'd2) ? snac_joy : (status[3] ? joyA_int : joyB_int);
+// SNAC Autofire selectable on 2 speed (Fast and Slow)
+wire [1:0] snac_af_mode = status[90:89];
+reg [21:0] snac_af_cnt;
+always @(posedge clk_sys) snac_af_cnt <= snac_af_cnt + 1'd1;
+// Slow ~7.6 Hz | Fast ~15.3 Hz  (clk_sys = 32 MHz)
+wire snac_af_clk = (snac_af_mode == 2'd2) ? snac_af_cnt[20] : snac_af_cnt[21];
+wire [6:0] snac_joy_af = {snac_joy[6:5], snac_af_mode ? (snac_joy[4] & snac_af_clk) : snac_joy[4], snac_joy[3:0]};
+
+// swap joysticks if requested
+wire [6:0] joyA_base = status[3] ? joyB_int : joyA_int;
+wire [6:0] joyB_base = status[3] ? joyA_int : joyB_int;
+wire [6:0] joyA_c64  = (snac_mode == 2'd1 || snac_mode == 2'd3) ? snac_joy_af : joyA_base;
+wire [6:0] joyB_c64  = (snac_mode == 2'd2 || snac_mode == 2'd3) ? snac_joy_af : joyB_base;
 
 wire [7:0] paddle_1 = status[3] ? pd3 : pd1;
 wire [7:0] paddle_2 = status[3] ? pd4 : pd2;
@@ -695,7 +725,6 @@ always @(posedge clk_sys) begin
 		
 		if (load_tap) begin
 			if (ioctl_addr == 0)  ioctl_load_addr <= TAP_ADDR;
-			if (ioctl_addr == 12) tap_version <= ioctl_data[1:0];
 			ioctl_req_wr <= 1;
 		end
 
@@ -945,6 +974,10 @@ fpga64_sid_iec fpga64
 	.nmi_ack(nmi_ack),
 	.freeze_key(freeze_key),
 	.tape_play(tape_play),
+	.tape_rew(tape_key_rew),
+	.tape_stop(tape_key_stop),
+	.tape_ff(tape_key_ff),
+	.tape_reset_counter(tape_key_counter_reset),
 	.mod_key(mod_key),
 	.roml(romL),
 	.romh(romH),
@@ -1434,9 +1467,80 @@ drv_overlay drv_ovl (
 	.pixel_color(ovl_color)
 );
 
-reg [1:0] ovl_color_sync;
+wire       tape_play;
+wire       tape_key_rew;
+wire       tape_key_stop;
+wire       tape_key_ff;
+wire       tape_key_counter_reset;
+
+wire       cass_write;
+wire       cass_motor;
+wire       cass_sense;
+wire       cass_read;
+wire       cass_run;
+wire       cass_finish;
+
+wire       tap_loaded;
+wire [24:0] tap_play_addr;
+wire [24:0] tap_last_addr;
+wire [2:0]  tc_color;
+
+tape_subsystem tape_subsystem
+(
+	.clk(clk_sys),
+	.ce(ce_sys),
+	.reset_n(reset_n),
+	.hblank(hblank),
+	.vblank(vblank),
+	.ntsc(ntsc),
+
+	.ioctl_download(ioctl_download),
+	.ioctl_wr(ioctl_wr),
+	.ioctl_addr(ioctl_addr),
+	.ioctl_data(ioctl_data),
+	.load_tap(load_tap),
+	.tap_scanner_wait(tap_scanner_wait),
+
+	.io_cycle(io_cycle),
+	.sdram_data(sdram_data),
+
+	.osd_play(status[7]),
+	.osd_stop(status[95]),
+	.osd_rew(status[93]),
+	.osd_ff(status[94]),
+	.osd_unload(status[23]),
+	.osd_counter_reset(status[91]),
+	.counter_enable(status[92]),
+	.tape_autoplay_off(status[39]),
+
+	.key_play(tape_play),
+	.key_stop(tape_key_stop),
+	.key_rew(tape_key_rew),
+	.key_ff(tape_key_ff),
+	.key_counter_reset(tape_key_counter_reset),
+
+	.cass_write(cass_write),
+	.cass_motor(cass_motor),
+	.cass_sense(cass_sense),
+	.cass_read(cass_read),
+	.cass_run(cass_run),
+	.cass_finish(cass_finish),
+
+	.tap_loaded(tap_loaded),
+	.tap_play_addr(tap_play_addr),
+	.tap_last_addr(tap_last_addr),
+
+	.pixel_color(tc_color)
+);
+
+wire cass_snd = cass_read & ~cass_run & status[11] & ~cass_finish;
+
+// Combina i due overlay: il contagiri ha priorita' dove disegna
+wire [2:0] ovl_mix = (tc_color != 3'd0) ? tc_color : {1'b0, ovl_color};
+
+reg [2:0] ovl_color_sync;
 always @(posedge CLK_VIDEO) begin
-    ovl_color_sync <= ovl_color;
+    ovl_color_sync <= ovl_mix;
 end
 
 video_mixer #(.GAMMA(1)) video_mixer
@@ -1448,10 +1552,12 @@ video_mixer #(.GAMMA(1)) video_mixer
 	.gamma_bus(gamma_bus),
 
 	.ce_pix(ce_pix),
-	 // overlay colors: 0=Transparent, 1=Green, 2=Yellow, 3=Red
-	.R((ovl_color_sync == 2 || ovl_color_sync == 3) ? 8'hFF : (ovl_color_sync == 1 ? 8'h00 : r)),
-	.G((ovl_color_sync == 1 || ovl_color_sync == 2) ? 8'hFF : (ovl_color_sync == 3 ? 8'h00 : g)),
-	.B((ovl_color_sync != 0) ? 8'h00 : b),
+	 // overlay colors: 0=Transparent, 1=Green, 2=Yellow, 3=Red, 4=Blue
+	.R((ovl_color_sync == 3'd2 || ovl_color_sync == 3'd3) ? 8'hFF :
+	   (ovl_color_sync == 3'd1 || ovl_color_sync == 3'd4) ? 8'h00 : r),
+	.G((ovl_color_sync == 3'd1 || ovl_color_sync == 3'd2) ? 8'hFF :
+	   (ovl_color_sync == 3'd3 || ovl_color_sync == 3'd4) ? 8'h00 : g),
+	.B((ovl_color_sync == 3'd4) ? 8'hFF : (ovl_color_sync != 3'd0) ? 8'h00 : b),
 	.HSync(hsync_out),
 	.VSync(vsync_out),
 	.HBlank(hblank),
@@ -1579,72 +1685,7 @@ assign AUDIO_R = aro;
 assign AUDIO_S = 1;
 assign AUDIO_MIX = status[19:18];
 
-//------------- TAP -------------------
-
-wire       tap_download = ioctl_download & load_tap;
-wire       tap_reset    = ~reset_n | tap_download | status[23] | !tap_last_addr | cass_finish | (cass_run & ((tap_last_addr - tap_play_addr) < 80));
-wire       tap_loaded   = (tap_play_addr < tap_last_addr);                                    // ^^ auto-unload if motor stopped at the very end ^^
-wire       tap_play_btn = status[7] | tape_play;
-wire       tape_play;
-
-reg [24:0] tap_play_addr;
-reg [24:0] tap_last_addr;
-reg  [1:0] tap_wrreq;
-wire       tap_wrfull;
-reg  [1:0] tap_version;
-reg        tap_start;
-
-always @(posedge clk_sys) begin
-	reg io_cycleD;
-	reg read_cyc;
-
-	io_cycleD <= io_cycle;
-	tap_wrreq <= tap_wrreq << 1;
-
-	if(tap_reset) begin
-		//C1530 module requires one more byte at the end due to fifo early check.
-		tap_last_addr <= tap_download ? ioctl_addr+2'd2 : 25'd0;
-		tap_play_addr <= 0;
-		tap_start     <= ~status[39] & tap_download;
-		read_cyc      <= 0;
-	end
-	else begin
-		tap_start <= 0;
-		if (~io_cycle & io_cycleD & ~tap_wrfull & tap_loaded) read_cyc <= 1;
-		if (io_cycle & io_cycleD & read_cyc) begin
-			tap_play_addr <= tap_play_addr + 1'd1;
-			read_cyc <= 0;
-			tap_wrreq[0] <= 1;
-		end
-	end
-end
-
-wire cass_write;
-wire cass_motor;
-wire cass_sense;
-wire cass_read;
-wire cass_run;
-wire cass_finish;
-wire cass_snd = cass_read & ~cass_run & status[11] & ~cass_finish;
-
-c1530 c1530
-(
-	.clk32(clk_sys),
-	.restart_tape(tap_reset),
-	.wav_mode(0),
-	.tap_version(tap_version),
-	.host_tap_in(sdram_data),
-	.host_tap_wrreq(tap_wrreq[1]),
-	.tap_fifo_wrfull(tap_wrfull),
-	.tap_fifo_error(cass_finish),
-	.cass_read(cass_read),
-	.cass_write(cass_write),
-	.cass_motor(cass_motor),
-	.cass_sense(cass_sense),
-	.cass_run(cass_run),
-	.osd_play_stop_toggle(tap_play_btn | tap_start),
-	.ear_input(0)
-);
+//------------- TAP handled by tape_subsystem -------------------
 
 reg use_tape;
 always @(posedge clk_sys) begin

--- a/rtl/fpga64_keyboard.vhd
+++ b/rtl/fpga64_keyboard.vhd
@@ -52,6 +52,10 @@ entity fpga64_keyboard is
 		restore_key : out std_logic;
 		mod_key     : out std_logic;
 		tape_play   : out std_logic;
+		tape_rew    : out std_logic;
+		tape_stop   : out std_logic;
+		tape_ff     : out std_logic;
+		tape_reset_counter : out std_logic;
 		
 		-- Config
 		-- backwardsReadingEnabled = 1 allows reversal of PIA registers to still work.
@@ -184,6 +188,13 @@ begin
 			if delay_cnt /= 0 then
 				delay_cnt <= delay_cnt - 1;
 			end if;
+
+			-- Datassette shortcuts are command pulses, not held key states.
+			tape_play <= '0';
+			tape_rew <= '0';
+			tape_stop <= '0';
+			tape_ff <= '0';
+			tape_reset_counter <= '0';
 
 			-- reading A, scan pattern on B
 			pao(0) <= pai(0) and joyB(0) and
@@ -413,21 +424,21 @@ begin
 					when X"5D" => key_pound <= pressed;
 					when X"66" => key_del <= pressed; 
 					when X"69" => if extended then key_equal   <= pressed; else key_1   <= pressed; end if;
-					when X"6B" => if extended then key_left    <= pressed; else key_4   <= pressed; end if;
+					when X"6B" => if extended then if key_ctrl = '1' and pressed = '1' then tape_rew <= '1'; else key_left <= pressed; end if; else key_4 <= pressed; end if; -- Ctrl+Left = Tape REW
 					when X"6C" => if extended then key_home    <= pressed; else key_7   <= pressed; end if;
 					when X"70" => if extended then key_inst    <= pressed; else key_0   <= pressed; end if;
-					when X"71" => if extended then key_del     <= pressed; else key_dot <= pressed; end if;
-					when X"72" => if extended then key_down    <= pressed; else key_2   <= pressed; end if;
+					when X"71" => if extended then if key_ctrl = '1' and pressed = '1' then tape_reset_counter <= '1'; else key_del <= pressed; end if; else key_dot <= pressed; end if; -- Ctrl+Delete = Tape Counter Reset
+					when X"72" => if extended then if key_ctrl = '1' and pressed = '1' then tape_stop <= '1'; else key_down <= pressed; end if; else key_2 <= pressed; end if; -- Ctrl+Down = Tape STOP
 					when X"73" => key_5 <= pressed; 
-					when X"74" => if extended then key_right   <= pressed; else key_6   <= pressed; end if;
-					when X"75" => if extended then key_up      <= pressed; else key_8   <= pressed; end if;
+					when X"74" => if extended then if key_ctrl = '1' and pressed = '1' then tape_ff <= '1'; else key_right <= pressed; end if; else key_6 <= pressed; end if; -- Ctrl+Right = Tape FFWD
+					when X"75" => if extended then if key_ctrl = '1' and pressed = '1' then tape_play <= '1'; else key_up <= pressed; end if; else key_8 <= pressed; end if; -- Ctrl+Up = Tape Play/Pause
 					when X"76" => key_runstop <= pressed; 
 					when X"78" => restore_key <= pressed; -- F11
 					when X"79" => key_plus <= pressed; 
 					when X"7A" => if extended then key_arrowup <= pressed; else key_3   <= pressed; end if;
 					when X"7B" => key_minus <= pressed; 
 					when X"7C" => key_star <= pressed; 
-					when X"7D" => if extended then tape_play <= pressed; else key_9   <= pressed; end if;
+					when X"7D" => if not extended then key_9 <= pressed; end if;
 					when others => null;
 				end case;
 			end if;
@@ -463,6 +474,10 @@ begin
 					key_runstop   <= '0';
 					restore_key   <= '0';
 					tape_play     <= '0';
+					tape_rew      <= '0';
+					tape_stop     <= '0';
+					tape_ff       <= '0';
+					tape_reset_counter <= '0';
 					key_arrowup   <= '0';
 					key_equal     <= '0';
 					key_arrowleft <= '0';

--- a/rtl/fpga64_sid_iec.vhd
+++ b/rtl/fpga64_sid_iec.vhd
@@ -96,6 +96,10 @@ port(
 	freeze_key  : out std_logic;
 	mod_key     : out std_logic;
 	tape_play   : out std_logic;
+	tape_rew    : out std_logic;
+	tape_stop   : out std_logic;
+	tape_ff     : out std_logic;
+	tape_reset_counter : out std_logic;
 
 	-- dma access
 	dma_req     : in  std_logic := '0';
@@ -888,6 +892,10 @@ port map (
 
 	restore_key => freeze_key,
 	tape_play => tape_play,
+	tape_rew => tape_rew,
+	tape_stop => tape_stop,
+	tape_ff => tape_ff,
+	tape_reset_counter => tape_reset_counter,
 	mod_key => mod_key,
 	backwardsReadingEnabled => '1'
 );

--- a/rtl/tap_scanner.sv
+++ b/rtl/tap_scanner.sv
@@ -1,0 +1,295 @@
+`timescale 1ns/1ps
+// ============================================================================
+// TAP scanner - builds an accurate counter -> TAP byte-offset map for FF/REW
+//
+// This module scans the TAP stream while it is being downloaded and converts the
+// raw pulse durations into real elapsed tape time.  The generated time_map lets
+// the top-level jump to the TAP byte offset corresponding to each absolute
+// mechanical tape-counter step.
+//
+// Accuracy notes:
+// - Supports TAP v0, v1 and v2 timing encodings.
+// - Uses the same 1 MHz TAP pulse timebase as the existing c1530 player,
+//   so the generated map stays aligned with the counter during playback.
+// - v1/v2 long pulses are mapped back to the *start* of the 00 xx xx xx pulse
+//   sequence, never into the middle of the 3-byte overflow value.  This is
+//   important because playback can only safely resume at a valid TAP token.
+// - No loader-specific assumptions are made; the map is based only on pulse
+//   durations, so turbo loaders, custom loaders, long silences, and v2 halfwave
+//   files are handled uniformly.
+// ============================================================================
+
+module tap_scanner #(
+	parameter int THRESH_BASE  = 2693,     // ms/counter step at tape start
+	parameter int THRESH_INC   = 6,        // added ms per counter step
+	parameter int ABS_MAX      = 8191,     // max absolute counter index for 13-bit map
+	parameter int MAP_AW       = 13        // 2^13 = 8192 entries
+) (
+	input        clk,
+	input        reset_n,
+
+	// ioctl TAP download stream
+	input        start,          // pulse at beginning of TAP download
+	input        tap_wr,         // ioctl_data valid for this byte
+	input [24:0] tap_addr,       // byte offset in TAP file (including 20-byte header)
+	input  [7:0] tap_data,
+	input        tap_done,       // pulse at end of TAP download
+
+	// time_map write port
+	output reg                  map_wr,
+	output reg [MAP_AW-1:0]     map_addr,
+	output reg [24:0]           map_data,  // safe TAP byte offset to resume from
+
+	// status
+	output reg                  busy,
+	output reg                  ready,
+	output reg [MAP_AW-1:0]     map_max,
+
+	// Asserted while the scanner is catching up writing map entries.  The top
+	// level must OR this into ioctl_wait for TAP downloads, otherwise bytes can
+	// arrive while ST_WRITE_MAP is emitting multiple counter boundaries.
+	output                       wait_req
+);
+
+// ---------------------------------------------------------------------------
+// Playback timing.
+// c1530 advances TAP pulse counters once per 32 MHz / 32 tick, so one TAP
+// cycle is treated as 1 us by the existing player.  The FF/REW map must use
+// the same timebase or counter positions will drift from real playback.
+// ---------------------------------------------------------------------------
+localparam int TAP_PLAYER_Q10 = 1_024_000; // 1000 cycles/ms in Q10
+
+// TAP header fields used by the scanner.
+reg [1:0] tap_version;
+
+// Accumulators and mechanical-counter model
+reg [MAP_AW-1:0] count;
+reg [47:0] time_acc_cycles;
+reg [47:0] target_cycles;
+reg [15:0] threshold_ms;
+reg [31:0] cycles_per_ms_q10;
+
+// Last decoded pulse span. Map entries are written to the nearest safe TAP
+// token boundary (start or next token), which greatly improves seeks across
+// very long pulses/silence while never resuming inside a multi-byte token.
+reg [47:0] pulse_start_cycles;
+reg [24:0] pulse_start_offset;
+reg [24:0] pulse_end_offset;
+
+// v1/v2 overflow-token state. A long pulse is encoded as 00 + 24-bit cycles.
+reg [1:0]  ovf_bytes_left;
+reg [23:0] ovf_duration;
+reg [24:0] ovf_start_offset;
+
+reg done_pending;
+
+localparam [2:0] ST_IDLE      = 3'd0;
+localparam [2:0] ST_HEADER    = 3'd1;
+localparam [2:0] ST_DATA      = 3'd2;
+localparam [2:0] ST_WRITE_MAP = 3'd3;
+localparam [2:0] ST_DONE      = 3'd4;
+reg [2:0] state;
+
+function automatic [47:0] ms_to_cycles_q10(input [15:0] ms, input [31:0] cyc_ms_q10);
+	begin
+		ms_to_cycles_q10 = ({32'd0, ms} * {16'd0, cyc_ms_q10}) >> 10;
+	end
+endfunction
+
+// ---------------------------------------------------------------------------
+// Decode current byte into a completed pulse, when possible.
+// For v1/v2 overflow, add_offset is the 00 marker offset, not byte 3 of the
+// duration field, so the top-level never resumes inside an overflow token.
+// ---------------------------------------------------------------------------
+reg        add_valid;
+reg [47:0] add_cycles;
+reg [24:0] add_offset;
+reg [23:0] ovf_duration_next;
+
+always @(*) begin
+	add_valid = 1'b0;
+	add_cycles = 48'd0;
+	add_offset = tap_addr;
+	ovf_duration_next = ovf_duration;
+
+	if (tap_wr && state == ST_DATA) begin
+		if (ovf_bytes_left != 0) begin
+			case (ovf_bytes_left)
+				2'd3: ovf_duration_next = {ovf_duration[23:8],  tap_data};
+				2'd2: ovf_duration_next = {ovf_duration[23:16], tap_data, ovf_duration[7:0]};
+				2'd1: ovf_duration_next = {tap_data, ovf_duration[15:0]};
+				default: ovf_duration_next = ovf_duration;
+			endcase
+
+			if (ovf_bytes_left == 2'd1) begin
+				add_valid = 1'b1;
+				add_cycles = {24'd0, ovf_duration_next};
+				add_offset = ovf_start_offset;
+			end
+		end else if (tap_data == 8'd0) begin
+			if (tap_version == 2'd0) begin
+				// v0: 00 is a fixed 20000-cycle pulse.
+				add_valid = 1'b1;
+				add_cycles = 48'd20000;
+				add_offset = tap_addr;
+			end
+			// v1/v2: 00 starts an overflow token; pulse completes after 3 bytes.
+		end else begin
+			add_valid = 1'b1;
+			add_cycles = {40'd0, tap_data} * 48'd8;
+			add_offset = tap_addr;
+		end
+	end
+end
+
+
+// Request HPS download throttling whenever this pulse may cross one or more
+// counter boundaries. This prevents losing TAP bytes while the FSM emits map
+// entries for long pulses/silences.
+wire [47:0] time_acc_after_add = time_acc_cycles + add_cycles;
+assign wait_req = busy && ((state == ST_WRITE_MAP && time_acc_cycles >= target_cycles) ||
+                           (state == ST_DATA && add_valid && time_acc_after_add >= target_cycles));
+
+wire [47:0] dist_to_pulse_start = target_cycles - pulse_start_cycles;
+wire [47:0] dist_to_pulse_end   = time_acc_cycles - target_cycles;
+wire [24:0] nearest_safe_offset = (dist_to_pulse_start <= dist_to_pulse_end) ? pulse_start_offset : pulse_end_offset;
+
+// ---------------------------------------------------------------------------
+// FSM
+// ---------------------------------------------------------------------------
+always @(posedge clk) begin
+	if (!reset_n) begin
+		state <= ST_IDLE;
+		busy <= 1'b0;
+		ready <= 1'b0;
+		map_wr <= 1'b0;
+		map_addr <= {MAP_AW{1'b0}};
+		map_data <= 25'd0;
+		map_max <= {MAP_AW{1'b0}};
+		count <= {MAP_AW{1'b0}};
+		time_acc_cycles <= 48'd0;
+		target_cycles <= 48'd0;
+		threshold_ms <= THRESH_BASE[15:0];
+		cycles_per_ms_q10 <= TAP_PLAYER_Q10;
+		pulse_start_cycles <= 48'd0;
+		pulse_start_offset <= 25'd20;
+		pulse_end_offset <= 25'd20;
+		ovf_bytes_left <= 2'd0;
+		ovf_duration <= 24'd0;
+		ovf_start_offset <= 25'd0;
+		done_pending <= 1'b0;
+		tap_version <= 2'd0;
+	end else begin
+		map_wr <= 1'b0;
+
+		if (tap_done) done_pending <= 1'b1;
+		else if (!busy) done_pending <= 1'b0;
+
+		case (state)
+			ST_IDLE: begin
+				if (start) begin
+					state <= ST_HEADER;
+					busy <= 1'b1;
+					ready <= 1'b0;
+					count <= {MAP_AW{1'b0}};
+					map_max <= {MAP_AW{1'b0}};
+					time_acc_cycles <= 48'd0;
+					threshold_ms <= THRESH_BASE[15:0];
+					ovf_bytes_left <= 2'd0;
+					ovf_duration <= 24'd0;
+					ovf_start_offset <= 25'd0;
+					done_pending <= 1'b0;
+					cycles_per_ms_q10 <= TAP_PLAYER_Q10;
+					pulse_start_cycles <= 48'd0;
+					pulse_start_offset <= 25'd20;
+					pulse_end_offset <= 25'd20;
+				end
+			end
+
+			ST_HEADER: begin
+				if (tap_wr && tap_addr < 25'd20) begin
+					if (tap_addr == 25'd12) tap_version <= tap_data[1:0];
+
+					if (tap_addr == 25'd19) begin
+						cycles_per_ms_q10 <= TAP_PLAYER_Q10;
+						target_cycles <= ms_to_cycles_q10(THRESH_BASE[15:0], TAP_PLAYER_Q10);
+
+						// map[0] must be the beginning of the TAP stream so REW-to-start is safe.
+						map_wr <= 1'b1;
+						map_addr <= {MAP_AW{1'b0}};
+						map_data <= 25'd0;
+						count <= {{(MAP_AW-1){1'b0}}, 1'b1};
+						state <= ST_DATA;
+					end
+				end
+			end
+
+			ST_DATA: begin
+				if (tap_wr) begin
+					if (ovf_bytes_left != 0) begin
+						ovf_duration <= ovf_duration_next;
+						ovf_bytes_left <= ovf_bytes_left - 1'd1;
+					end else if (tap_data == 8'd0 && tap_version != 2'd0) begin
+						ovf_bytes_left <= 2'd3;
+						ovf_duration <= 24'd0;
+						ovf_start_offset <= tap_addr;
+					end
+				end
+
+				if (add_valid) begin
+					pulse_start_cycles <= time_acc_cycles;
+					pulse_start_offset <= add_offset;
+					pulse_end_offset <= tap_addr + 1'd1;
+					time_acc_cycles <= time_acc_cycles + add_cycles;
+					state <= ST_WRITE_MAP;
+				end else if (done_pending) begin
+					state <= ST_WRITE_MAP;
+				end
+			end
+
+			ST_WRITE_MAP: begin
+				if ((count < ABS_MAX[MAP_AW-1:0]) && (count < {MAP_AW{1'b1}}) && (time_acc_cycles >= target_cycles)) begin
+					map_wr <= 1'b1;
+					map_addr <= count;
+					map_data <= nearest_safe_offset;
+					count <= count + 1'd1;
+					threshold_ms <= threshold_ms + THRESH_INC[15:0];
+					target_cycles <= target_cycles + ms_to_cycles_q10(threshold_ms + THRESH_INC[15:0], cycles_per_ms_q10);
+				end else begin
+					map_max <= count;
+					if (done_pending) begin
+						state <= ST_DONE;
+						ready <= 1'b1;
+						busy <= 1'b0;
+					end else begin
+						state <= ST_DATA;
+					end
+				end
+			end
+
+			ST_DONE: begin
+				if (start) begin
+					state <= ST_HEADER;
+					busy <= 1'b1;
+					ready <= 1'b0;
+					count <= {MAP_AW{1'b0}};
+					map_max <= {MAP_AW{1'b0}};
+					time_acc_cycles <= 48'd0;
+					threshold_ms <= THRESH_BASE[15:0];
+					ovf_bytes_left <= 2'd0;
+					ovf_duration <= 24'd0;
+					ovf_start_offset <= 25'd0;
+					done_pending <= 1'b0;
+					cycles_per_ms_q10 <= TAP_PLAYER_Q10;
+					pulse_start_cycles <= 48'd0;
+					pulse_start_offset <= 25'd20;
+					pulse_end_offset <= 25'd20;
+				end
+			end
+
+			default: state <= ST_IDLE;
+		endcase
+	end
+end
+
+endmodule

--- a/rtl/tap_time_map.sv
+++ b/rtl/tap_time_map.sv
@@ -1,0 +1,32 @@
+`timescale 1ns/1ps
+// ============================================================================
+// TAP time map - dual-port block RAM per mappa contatore -> byte offset
+//
+// Porta A: scrittura dal tap_scanner durante il caricamento.
+// Porta B: lettura dal top-level durante FF/REW.
+// ============================================================================
+
+module tap_time_map #(
+	parameter int AW = 13,      // indirizzo: 2^AW entry
+	parameter int DW = 25       // 25 bit per offset byte (max 4 MB in SDRAM)
+) (
+	input        clk,
+
+	// Porta scrittura (scanner)
+	input  [AW-1:0] wr_addr,
+	input  [DW-1:0] wr_data,
+	input           wr_en,
+
+	// Porta lettura (top-level)
+	input  [AW-1:0] rd_addr,
+	output reg [DW-1:0] rd_data
+);
+
+	reg [DW-1:0] ram [0:(1<<AW)-1];
+
+	always @(posedge clk) begin
+		if (wr_en) ram[wr_addr] <= wr_data;
+		rd_data <= ram[rd_addr];
+	end
+
+endmodule

--- a/rtl/tape_counter.sv
+++ b/rtl/tape_counter.sv
@@ -1,0 +1,527 @@
+`timescale 1ns/1ps
+// ============================================================================
+// C1530 Datassette - Tape Counter with on-screen overlay
+//
+// Improved version of the mechanical tape counter.
+//
+// Key fixes/changes vs. the original:
+//  1. FIXED: rewind digit decrement (the original accidentally incremented d_tens
+//     when rolling under 0, breaking the counter during REW).
+//  2. Added active-low reset_n input for clean FPGA initialization.
+//  3. Replaced the huge nested digit case with a compact FONT ROM array.
+//  4. Encapsulated BCD increment/decrement in helper functions.
+//  5. Derived clock-divider values from parameters instead of hard-coded literals.
+//  6. Used always_ff / always_comb consistently and cleaned up magic numbers.
+//  7. Made overlay position configurable via parameters.
+//  8. FIX: Widened tick_div / wind_div to prevent counter freeze on clocks >= 65MHz.
+//  9. FIX: Uncoupled vblank coordinate resets from ce to guarantee clean sweeps.
+// ============================================================================
+
+module tape_counter #(
+	parameter int CLK_HZ       = 32_000_000,
+	parameter int TICK_HZ      = 1000,        // 1 kHz -> 1 tick = 1 ms of tape
+	parameter int THRESH_BASE  = 2693,        // ms/rotation at tape start
+	parameter int THRESH_INC   = 6,           // ms/rotation added per rotation
+	parameter int ABS_MAX      = 8191,        // absolute rotation saturation / 13-bit time-map limit
+	parameter int WIND_MS      = 476,         // ms per counter click during FF/REW
+	parameter int POS_X_PAL    = 316,         // align with drive overlay X origin (PAL)
+	parameter int POS_X_NTSC   = 323,         // align with drive overlay X origin (NTSC)
+	parameter int POS_Y_PAL    = 249,         // third drive-overlay row (PAL: 237 + 12)
+	parameter int POS_Y_NTSC   = 241          // third drive-overlay row (NTSC: 229 + 12)
+) (
+	input        clk,         // clk_sys (~32 MHz)
+	input        ce,          // ~8 MHz pixel clock-enable
+	input        reset_n,     // active-low reset
+	input        hblank,
+	input        vblank,
+	input        ntsc,
+
+	// Control
+	input        enable,        // 1 = overlay visible
+	input        tape_loaded,   // 1 = a tape is loaded
+	input        new_tape,      // pulse/level: reset counter & position
+	input        counter_reset, // OSD "Tape Counter Reset" pulse
+	input [24:0] tap_play_addr, // current TAP file position
+	input [24:0] tap_last_addr, // total TAP file size
+
+	// Transport state from c1530 (active low)
+	input        cass_run,      // 0 = motor rotating
+	input        cass_sense,    // 0 = PLAY pressed
+
+	// Winding (top-level guarantees mutual exclusion)
+	input        ff,            // 1 = fast-forward active
+	input        rew,           // 1 = rewind active
+
+	// Synchronization back to the top-level tape position
+	output       wind_step,
+	output [12:0] abs_count,       // absolute counter value (index into time_map)
+	output       at_tape_start,
+
+	// Video mixer: 0=Transparent, 1=Green, 2=Yellow, 3=Red, 4=Blue
+	output [2:0] pixel_color
+);
+
+// ---------------------------------------------------------------------------
+// Local constants
+// ---------------------------------------------------------------------------
+localparam TICK_DIV   = CLK_HZ / TICK_HZ;   // 32000 at 32 MHz / 1 kHz
+localparam WIND_TICKS = (WIND_MS < 1) ? 1 : WIND_MS;
+
+localparam [2:0] C_TRANSPARENT = 3'd0;
+localparam [2:0] C_GREEN       = 3'd1;
+localparam [2:0] C_YELLOW      = 3'd2;
+localparam [2:0] C_RED         = 3'd3;
+localparam [2:0] C_BLUE        = 3'd4;
+
+// ---------------------------------------------------------------------------
+// Font ROM Lookup function (Avoids iverilog multi-dimensional array limitations)
+// ---------------------------------------------------------------------------
+function automatic [4:0] get_font_row(input [4:0] char, input [2:0] row);
+	reg [4:0] val;
+	begin
+		val = 5'b00000;
+		case (char)
+			5'd0: begin
+				case(row)
+					0: val = 5'b01110; 1: val = 5'b10001; 2: val = 5'b10001; 3: val = 5'b10001; 4: val = 5'b01110;
+				endcase
+			end
+			5'd1: begin
+				case(row)
+					0: val = 5'b00100; 1: val = 5'b01100; 2: val = 5'b00100; 3: val = 5'b00100; 4: val = 5'b01110;
+				endcase
+			end
+			5'd2: begin
+				case(row)
+					0: val = 5'b01110; 1: val = 5'b10001; 2: val = 5'b00110; 3: val = 5'b01000; 4: val = 5'b11111;
+				endcase
+			end
+			5'd3: begin
+				case(row)
+					0: val = 5'b11110; 1: val = 5'b00001; 2: val = 5'b01110; 3: val = 5'b00001; 4: val = 5'b11110;
+				endcase
+			end
+			5'd4: begin
+				case(row)
+					0: val = 5'b10001; 1: val = 5'b10001; 2: val = 5'b11111; 3: val = 5'b00001; 4: val = 5'b00001;
+				endcase
+			end
+			5'd5: begin
+				case(row)
+					0: val = 5'b11111; 1: val = 5'b10000; 2: val = 5'b11110; 3: val = 5'b00001; 4: val = 5'b11110;
+				endcase
+			end
+			5'd6: begin
+				case(row)
+					0: val = 5'b01110; 1: val = 5'b10000; 2: val = 5'b11110; 3: val = 5'b10001; 4: val = 5'b01110;
+				endcase
+			end
+			5'd7: begin
+				case(row)
+					0: val = 5'b11111; 1: val = 5'b00001; 2: val = 5'b00010; 3: val = 5'b00100; 4: val = 5'b00100;
+				endcase
+			end
+			5'd8: begin
+				case(row)
+					0: val = 5'b01110; 1: val = 5'b10001; 2: val = 5'b01110; 3: val = 5'b10001; 4: val = 5'b01110;
+				endcase
+			end
+			5'd9: begin
+				case(row)
+					0: val = 5'b01110; 1: val = 5'b10001; 2: val = 5'b01111; 3: val = 5'b00001; 4: val = 5'b01110;
+				endcase
+			end
+			// STOP: filled square
+			5'd26: begin
+				case(row)
+					0: val = 5'b11111; 1: val = 5'b11111; 2: val = 5'b11111; 3: val = 5'b11111; 4: val = 5'b11111;
+				endcase
+			end
+			// PAUSE: two vertical bars
+			5'd27: begin
+				case(row)
+					0: val = 5'b11011; 1: val = 5'b11011; 2: val = 5'b11011; 3: val = 5'b11011; 4: val = 5'b11011;
+				endcase
+			end
+			// PLAY: right-pointing triangle
+			5'd28: begin
+				case(row)
+					0: val = 5'b10000; 1: val = 5'b11000; 2: val = 5'b11100; 3: val = 5'b11000; 4: val = 5'b10000;
+				endcase
+			end
+			// REW: double left triangles
+			5'd29: begin
+				case(row)
+					0: val = 5'b00101; 1: val = 5'b01101; 2: val = 5'b11111; 3: val = 5'b01101; 4: val = 5'b00101;
+				endcase
+			end
+			// FFWD: double right triangles
+			5'd30: begin
+				case(row)
+					0: val = 5'b10100; 1: val = 5'b10110; 2: val = 5'b11111; 3: val = 5'b10110; 4: val = 5'b10100;
+				endcase
+			end
+			// LOAD/cassette icon
+			5'd31: begin
+				case(row)
+					0: val = 5'b11111; 1: val = 5'b10001; 2: val = 5'b11111; 3: val = 5'b01010; 4: val = 5'b11111;
+				endcase
+			end
+			default: val = 5'b00000;
+		endcase
+		get_font_row = val;
+	end
+endfunction
+
+
+// ---------------------------------------------------------------------------
+// BCD helpers
+// ---------------------------------------------------------------------------
+function automatic [11:0] bcd_inc(input [11:0] bcd);
+	reg [3:0] h, t, o;
+	begin
+		h = bcd[11:8]; t = bcd[7:4]; o = bcd[3:0];
+		if (o == 4'd9) begin
+			o = 4'd0;
+			if (t == 4'd9) begin
+				t = 4'd0;
+				if (h == 4'd9) h = 4'd0;
+				else           h = h + 4'd1;
+			end else begin
+				t = t + 4'd1;
+			end
+		end else begin
+			o = o + 4'd1;
+		end
+		bcd_inc = {h, t, o};
+	end
+endfunction
+
+function automatic [11:0] bcd_dec(input [11:0] bcd);
+	reg [3:0] h, t, o;
+	begin
+		h = bcd[11:8]; t = bcd[7:4]; o = bcd[3:0];
+		if (o == 4'd0) begin
+			o = 4'd9;
+			if (t == 4'd0) begin
+				t = 4'd9;
+				if (h == 4'd0) h = 4'd9;
+				else           h = h - 4'd1;
+			end else begin
+				t = t - 4'd1;   // FIX: original had +1 here, causing REW to go wrong
+			end
+		end else begin
+			o = o - 4'd1;
+		end
+		bcd_dec = {h, t, o};
+	end
+endfunction
+
+// ---------------------------------------------------------------------------
+// Tick generators
+// ---------------------------------------------------------------------------
+// FIX: Widened tick_div dynamically to prevent wrap-around bugs at high frequencies
+reg [$clog2(TICK_DIV):0] tick_div = 0;
+reg                      tick_1k  = 0;
+always @(posedge clk) begin
+	if (!reset_n) begin
+		tick_div <= 0;
+		tick_1k  <= 0;
+	end else begin
+		tick_1k <= 0;
+		if (tick_div >= TICK_DIV[$clog2(TICK_DIV):0] - 1'd1) begin
+			tick_div <= 0;
+			tick_1k  <= 1;
+		end else begin
+			tick_div <= tick_div + 1'd1;
+		end
+	end
+end
+
+// FIX: Widened wind_div to dynamically fit WIND_TICKS values
+reg [$clog2(WIND_TICKS):0] wind_div  = 0;
+reg                        wind_tick = 0;
+always @(posedge clk) begin
+	if (!reset_n) begin
+		wind_div  <= 0;
+		wind_tick <= 0;
+	end else begin
+		wind_tick <= 0;
+		if (!winding) begin
+			wind_div <= 0;
+		end else if (tick_1k) begin
+			if (wind_div >= WIND_TICKS[$clog2(WIND_TICKS):0] - 1'd1) begin
+				wind_div  <= 0;
+				wind_tick <= 1;
+			end else begin
+				wind_div <= wind_div + 1'd1;
+			end
+		end
+	end
+end
+
+// ---------------------------------------------------------------------------
+// Transport state (combinational)
+// ---------------------------------------------------------------------------
+wire at_end  = tape_loaded & (tap_play_addr >= tap_last_addr);
+wire winding = tape_loaded & (ff | rew); // allow REW even after end-of-tape
+wire playing = tape_loaded & ~at_end & ~cass_run & ~cass_sense & ~winding;
+wire paused  = tape_loaded & ~at_end & cass_run & ~cass_sense & ~winding;
+// ---------------------------------------------------------------------------
+// Physical counter model: accumulating time vs. growing reel radius
+// ---------------------------------------------------------------------------
+reg [15:0] pos_acc   = 0;
+reg [12:0] abs_count_r = 0;
+reg [15:0] threshold = THRESH_BASE[15:0];
+reg [3:0]  d_ones    = 0;
+reg [3:0]  d_tens    = 0;
+reg [3:0]  d_huns    = 0;
+
+reg counter_reset_d = 0;
+wire counter_reset_edge = counter_reset & ~counter_reset_d;
+
+always @(posedge clk) begin
+	if (!reset_n) begin
+		pos_acc         <= 0;
+		abs_count_r     <= 0;
+		threshold       <= THRESH_BASE[15:0];
+		d_ones          <= 0;
+		d_tens          <= 0;
+		d_huns          <= 0;
+		counter_reset_d <= 0;
+	end else begin
+		counter_reset_d <= counter_reset;
+
+		if (new_tape || !tape_loaded) begin
+			pos_acc     <= 0;
+			abs_count_r <= 0;
+			threshold   <= THRESH_BASE[15:0];
+			d_ones      <= 0;
+			d_tens      <= 0;
+			d_huns      <= 0;
+		end else begin
+			if (counter_reset_edge) begin
+				// Mechanical reset only clears the digits; absolute position is kept.
+				d_ones <= 0;
+				d_tens <= 0;
+				d_huns <= 0;
+			end
+
+			if (tick_1k && playing && !winding) begin
+				if (pos_acc + 1'd1 >= threshold) begin
+					pos_acc <= (pos_acc + 1'd1) - threshold;
+					if (abs_count_r < ABS_MAX[12:0]) begin
+						abs_count_r <= abs_count_r + 1'd1;
+						threshold <= threshold + THRESH_INC[15:0];
+					end
+					if (!counter_reset_edge) begin
+						{d_huns, d_tens, d_ones} <= bcd_inc({d_huns, d_tens, d_ones});
+					end
+				end else begin
+					pos_acc <= pos_acc + 1'd1;
+				end
+			end
+
+			if (wind_tick && !counter_reset_edge) begin
+				pos_acc <= 0;
+				if (ff && abs_count_r < ABS_MAX[12:0]) begin
+					abs_count_r <= abs_count_r + 1'd1;
+					threshold <= threshold + THRESH_INC[15:0];
+					{d_huns, d_tens, d_ones} <= bcd_inc({d_huns, d_tens, d_ones});
+				end else if (rew && abs_count_r != 0) begin
+					abs_count_r <= abs_count_r - 1'd1;
+					threshold <= (threshold >= THRESH_BASE[15:0] + THRESH_INC[15:0])
+					             ? threshold - THRESH_INC[15:0]
+					             : THRESH_BASE[15:0];
+					{d_huns, d_tens, d_ones} <= bcd_dec({d_huns, d_tens, d_ones});
+				end
+			end
+		end
+	end
+end
+
+// ===========================================================================
+// Rendering overlay
+// ===========================================================================
+localparam bit [9:0] TC_W = 10'd30; // 5 cells * 6 px
+localparam bit [9:0] TC_H = 10'd6;  // 5 font + 1 spacing
+
+wire [9:0] base_x = ntsc ? POS_X_NTSC[9:0] : POS_X_PAL[9:0];
+wire [9:0] base_y = ntsc ? POS_Y_NTSC[9:0] : POS_Y_PAL[9:0];
+
+reg [9:0] x_pos = 0;
+reg [9:0] y_pos = 0;
+reg       old_hblank = 0;
+
+always @(posedge clk) begin
+	if (!reset_n) begin
+		x_pos      <= 0;
+		y_pos      <= 0;
+		old_hblank <= 0;
+	end else begin
+		if (hblank) x_pos <= 0;
+		else if (ce) x_pos <= x_pos + 1'd1;
+
+		if (ce) old_hblank <= hblank;
+
+		if (vblank) y_pos <= 0;
+		else if (ce) begin
+			if (old_hblank && !hblank) y_pos <= y_pos + 1'd1;
+		end
+	end
+end
+
+wire tc_visible = enable && tape_loaded;
+wire tc_area = tc_visible &&
+               (x_pos >= base_x) && (x_pos < base_x + TC_W) &&
+               (y_pos >= base_y) && (y_pos < base_y + TC_H);
+
+reg [2:0] tc_col_r = 0;
+reg [2:0] tc_px_r  = 0;
+reg [2:0] tc_py_r  = 0;
+
+always @(posedge clk) begin
+	if (!reset_n) begin
+		tc_col_r <= 0;
+		tc_px_r  <= 0;
+	end else if (ce) begin
+		// tc_col_r / tc_px_r: aggiornati ogni pixel nella zona overlay
+		if (hblank) begin
+			tc_col_r <= 0;
+			tc_px_r  <= 0;
+		end else if (x_pos == base_x - 10'd1) begin
+			tc_col_r <= 0;
+			tc_px_r  <= 0;
+		end else if (tc_area) begin
+			if (tc_px_r == 3'd5) begin
+				tc_px_r  <= 0;
+				tc_col_r <= tc_col_r + 1'd1;
+			end else begin
+				tc_px_r  <= tc_px_r + 1'd1;
+			end
+		end
+	end
+end
+
+// FIX: Uncouple vblank coordinate resets from ce to guarantee clean sweeps under all conditions
+always @(posedge clk) begin
+	if (!reset_n) begin
+		tc_py_r <= 0;
+	end else begin
+		if (vblank) begin
+			tc_py_r <= 0;
+		end else if (ce) begin
+			if (old_hblank && !hblank) begin
+				if (y_pos == base_y - 10'd1) begin
+					tc_py_r <= 0;
+				end else if (y_pos >= base_y && y_pos < base_y + TC_H) begin
+					if (tc_py_r == 3'd5) tc_py_r <= 0;
+					else                 tc_py_r <= tc_py_r + 1'd1;
+				end else begin
+					tc_py_r <= 0;
+				end
+			end
+		end
+	end
+end
+
+// Character selection: transport-state glyph in col 0, then hundreds/tens/ones.
+reg [4:0] tc_state_char;
+always @(*) begin
+	if (ff)             tc_state_char = 5'd30; // FFWD
+	else if (rew)       tc_state_char = 5'd29; // REW
+	else if (playing)   tc_state_char = 5'd28; // PLAY
+	else if (paused)    tc_state_char = 5'd27; // PAUSE
+	else                tc_state_char = 5'd26; // STOP
+end
+
+reg [4:0] tc_char;
+always @(*) begin
+	case (tc_col_r)
+		3'd0: tc_char = tc_state_char;
+		3'd1: tc_char = 5'h11;              // blank space
+		3'd2: tc_char = {1'b0, d_huns};     // hundreds
+		3'd3: tc_char = {1'b0, d_tens};     // tens
+		3'd4: tc_char = {1'b0, d_ones};     // ones
+		default: tc_char = 5'h11;           // blank
+	endcase
+end
+
+wire valid_tc_pixel = tc_area && (tc_px_r < 5) && (tc_py_r < 5);
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 1: latch cell coordinates and state
+// ---------------------------------------------------------------------------
+reg [4:0] char_s1;
+reg [2:0] px_s1, py_s1;
+reg       valid_s1;
+reg [2:0] color_s1;
+
+always @(posedge clk) begin
+	if (!reset_n) begin
+		char_s1    <= 0;
+		px_s1      <= 0;
+		py_s1      <= 0;
+		valid_s1   <= 0;
+		color_s1   <= C_TRANSPARENT;
+	end else if (ce) begin
+		char_s1    <= tc_char;
+		px_s1      <= tc_px_r;
+		py_s1      <= tc_py_r;
+		valid_s1   <= valid_tc_pixel;
+		color_s1   <= (ff || rew) ? C_BLUE :
+		              playing    ? C_GREEN :
+		              paused     ? C_YELLOW : C_RED;
+	end
+end
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 2: font lookup
+// ---------------------------------------------------------------------------
+reg [4:0] font_row_s2;
+reg [2:0] px_s2;
+reg       valid_s2;
+reg [2:0] color_s2;
+
+always @(posedge clk) begin
+	if (!reset_n) begin
+		font_row_s2 <= 0;
+		px_s2       <= 0;
+		valid_s2    <= 0;
+		color_s2    <= C_TRANSPARENT;
+	end else if (ce) begin
+		font_row_s2 <= get_font_row(char_s1, py_s1);
+		px_s2       <= px_s1;
+		valid_s2    <= valid_s1;
+		color_s2    <= color_s1;
+	end
+end
+
+// ---------------------------------------------------------------------------
+// Pipeline stage 3: pixel shift and color
+// ---------------------------------------------------------------------------
+wire [2:0] px_rev   = (px_s2 < 5) ? 3'd4 - px_s2 : 3'd0;
+wire       pixel_on = (px_s2 < 5) ? font_row_s2[px_rev] : 1'b0;
+
+reg [2:0] pixel_color_out;
+always @(posedge clk) begin
+	if (!reset_n) begin
+		pixel_color_out <= C_TRANSPARENT;
+	end else if (ce) begin
+		if (valid_s2 && pixel_on)
+			pixel_color_out <= color_s2;
+		else
+			pixel_color_out <= C_TRANSPARENT;
+	end
+end
+
+assign pixel_color = pixel_color_out;
+
+// ---------------------------------------------------------------------------
+// Position synchronization outputs
+// ---------------------------------------------------------------------------
+assign wind_step     = wind_tick;
+assign abs_count     = abs_count_r;
+assign at_tape_start = (abs_count_r == 0);
+
+endmodule

--- a/rtl/tape_subsystem.sv
+++ b/rtl/tape_subsystem.sv
@@ -1,0 +1,368 @@
+`timescale 1ns/1ps
+// ============================================================================
+// C1530 Datassette subsystem
+//
+// Keeps the top-level clean by grouping all TAP/Datasette related logic:
+// - TAP load tracking and version capture
+// - accurate TAP time-map scanner for FF/REW
+// - counter -> TAP offset time map RAM
+// - FF/REW/STOP/PLAY transport state
+// - C1530 player instance
+// - tape counter video overlay
+//
+// The actual SDRAM read port remains owned by c64.sv.  This module exposes
+// tap_play_addr; c64.sv keeps using that address for the existing SDRAM TAP
+// prefetch cycle and feeds the returned byte back through sdram_data.
+// ============================================================================
+
+module tape_subsystem (
+	input         clk,
+	input         ce,
+	input         reset_n,
+	input         hblank,
+	input         vblank,
+	input         ntsc,
+
+	// TAP download/ioctl stream
+	input         ioctl_download,
+	input         ioctl_wr,
+	input  [24:0] ioctl_addr,
+	input   [7:0] ioctl_data,
+	input         load_tap,
+	output        tap_scanner_wait,
+
+	// Existing SDRAM TAP prefetch timing/data from top-level
+	input         io_cycle,
+	input   [7:0] sdram_data,
+
+	// OSD/key transport controls. Inputs are pulses except counter_enable.
+	input         osd_play,
+	input         osd_stop,
+	input         osd_rew,
+	input         osd_ff,
+	input         osd_unload,
+	input         osd_counter_reset,
+	input         counter_enable,
+	input         tape_autoplay_off,
+
+	input         key_play,
+	input         key_stop,
+	input         key_rew,
+	input         key_ff,
+	input         key_counter_reset,
+
+	// C1530/C64 cassette lines
+	input         cass_write,
+	input         cass_motor,
+	output        cass_sense,
+	output        cass_read,
+	output        cass_run,
+	output        cass_finish,
+
+	// Status back to top-level
+	output        tap_loaded,
+	output [24:0] tap_play_addr,
+	output [24:0] tap_last_addr,
+
+	// Overlay color: 0=transparent, 1=green, 2=yellow, 3=red, 4=blue
+	output [2:0]  pixel_color
+);
+
+wire       tap_download = ioctl_download & load_tap;
+wire       tap_reset;
+wire       tap_at_end;
+
+reg        tap_ready_gated;
+wire       tap_ready;
+wire       tap_scanner_busy;
+
+reg [24:0] tap_play_addr_r;
+reg [24:0] tap_last_addr_r;
+assign tap_play_addr = tap_play_addr_r;
+assign tap_last_addr = tap_last_addr_r;
+
+assign tap_reset  = ~reset_n | tap_download | osd_unload | !tap_last_addr_r;
+assign tap_loaded = (|tap_last_addr_r) && tap_ready_gated; // keep mounted at end-of-tape
+assign tap_at_end = tap_loaded && (tap_play_addr_r >= tap_last_addr_r);
+
+always @(posedge clk) begin
+	if (tap_reset) tap_ready_gated <= 1'b0;
+	else           tap_ready_gated <= tap_ready;
+end
+
+// TAP version is needed by c1530 while playing back from SDRAM.
+reg [1:0] tap_version;
+always @(posedge clk) begin
+	if (!reset_n) begin
+		tap_version <= 2'd0;
+	end else if (ioctl_wr && load_tap && ioctl_addr == 25'd12) begin
+		tap_version <= ioctl_data[1:0];
+	end
+end
+
+// --- TAP time map for accurate FF/REW ---
+wire [12:0] tap_map_max;
+wire [24:0] tap_map_wrdata;
+wire [12:0] tap_map_wraddr;
+wire        tap_map_wr;
+wire [24:0] tap_map_rddata;
+reg  [12:0] tap_map_rdaddr;
+reg         tap_map_update;
+reg         tap_map_update_d;
+
+reg         old_tap_download;
+wire        tap_download_start = ~old_tap_download & ioctl_download;
+wire        tap_done = old_tap_download & ~ioctl_download & load_tap;
+
+always @(posedge clk) old_tap_download <= ioctl_download;
+
+tap_scanner #(.THRESH_BASE(2693), .THRESH_INC(6), .ABS_MAX(8191), .MAP_AW(13)) tap_scanner
+(
+	.clk(clk),
+	.reset_n(reset_n),
+	.start(tap_download_start & load_tap),
+	.tap_wr(ioctl_wr & load_tap),
+	.tap_addr(ioctl_addr),
+	.tap_data(ioctl_data),
+	.tap_done(tap_done),
+	.map_wr(tap_map_wr),
+	.map_addr(tap_map_wraddr),
+	.map_data(tap_map_wrdata),
+	.busy(tap_scanner_busy),
+	.ready(tap_ready),
+	.map_max(tap_map_max),
+	.wait_req(tap_scanner_wait)
+);
+
+tap_time_map #(.AW(13), .DW(25)) tap_time_map
+(
+	.clk(clk),
+	.wr_addr(tap_map_wraddr),
+	.wr_data(tap_map_wrdata),
+	.wr_en(tap_map_wr),
+	.rd_addr(tap_map_rdaddr),
+	.rd_data(tap_map_rddata)
+);
+
+// --- Transport state shared by counter and C1530 feed control ---
+reg        tape_ff  = 1'b0;
+reg        tape_rew = 1'b0;
+wire       tape_winding = tape_ff | tape_rew;
+
+// --- Tape counter overlay ---
+wire [12:0] tc_abs_count;
+wire        tc_wind_step;
+wire        tc_at_start;
+
+tape_counter #(.ABS_MAX(8191)) tape_counter
+(
+	.clk(clk),
+	.ce(ce),
+	.reset_n(reset_n),
+	.hblank(hblank),
+	.vblank(vblank),
+	.ntsc(ntsc),
+
+	.enable(counter_enable),
+	.tape_loaded(tap_loaded),
+	.new_tape(tap_reset),
+	.counter_reset(osd_counter_reset | key_counter_reset),
+	.tap_play_addr(tap_play_addr_r),
+	.tap_last_addr(tap_last_addr_r),
+
+	.cass_run(cass_run),
+	.cass_sense(cass_sense),
+
+	.ff(tape_ff),
+	.rew(tape_rew),
+
+	.wind_step(tc_wind_step),
+	.abs_count(tc_abs_count),
+	.at_tape_start(tc_at_start),
+
+	.pixel_color(pixel_color)
+);
+
+// --- Transport and C1530 feed control ---
+// Pulses used to keep the C1530 FIFO aligned with seek operations.
+reg        tape_stop_pulse = 1'b0;
+reg        tape_seek_reset = 1'b0;
+
+reg        osd_ff_d = 1'b0,   key_ff_d = 1'b0;
+reg        osd_rew_d = 1'b0,  key_rew_d = 1'b0;
+reg        osd_play_d = 1'b0, key_play_d = 1'b0;
+reg        osd_stop_d = 1'b0, key_stop_d = 1'b0;
+wire       osd_ff_change   = osd_ff   ^ osd_ff_d;
+wire       osd_rew_change  = osd_rew  ^ osd_rew_d;
+wire       osd_play_change = osd_play ^ osd_play_d;
+wire       osd_stop_change = osd_stop ^ osd_stop_d;
+localparam [19:0] OSD_CMD_LOCKOUT = 20'd640000; // 20 ms at 32 MHz
+reg [19:0] osd_ff_lockout = 20'd0, osd_rew_lockout = 20'd0;
+reg [19:0] osd_play_lockout = 20'd0, osd_stop_lockout = 20'd0;
+wire       osd_ff_pulse   = osd_ff_change   & (osd_ff_lockout   == 20'd0);
+wire       osd_rew_pulse  = osd_rew_change  & (osd_rew_lockout  == 20'd0);
+wire       osd_play_pulse = osd_play_change & (osd_play_lockout == 20'd0);
+wire       osd_stop_pulse = osd_stop_change & (osd_stop_lockout == 20'd0);
+wire       key_ff_edge    = key_ff   & ~key_ff_d;
+wire       key_rew_edge   = key_rew  & ~key_rew_d;
+wire       ff_edge        = osd_ff_pulse   | key_ff_edge;
+wire       rew_edge       = osd_rew_pulse  | key_rew_edge;
+wire       play_edge      = osd_play_pulse | (key_play & ~key_play_d);
+wire       stop_edge      = osd_stop_pulse | (key_stop & ~key_stop_d);
+reg  [1:0] tap_wrreq;
+wire       tap_wrfull;
+reg        tap_start;
+reg        tape_play_pulse = 1'b0;
+
+always @(posedge clk) begin
+	reg io_cycleD;
+	reg read_cyc;
+
+	io_cycleD <= io_cycle;
+	tap_wrreq <= tap_wrreq << 1;
+	tap_map_update_d <= tap_map_update;
+	tap_map_update <= 1'b0;
+	tape_stop_pulse <= 1'b0;
+	tape_seek_reset <= 1'b0;
+	tape_play_pulse <= 1'b0;
+
+	// OSD command bits may produce a set/clear pair for one selection.  Detect
+	// level changes, then lock out the matching return edge so one selection maps
+	// to one transport command. Keyboard commands remain one-shot rising pulses.
+	if (osd_ff_lockout   != 20'd0) osd_ff_lockout   <= osd_ff_lockout   - 20'd1;
+	if (osd_rew_lockout  != 20'd0) osd_rew_lockout  <= osd_rew_lockout  - 20'd1;
+	if (osd_play_lockout != 20'd0) osd_play_lockout <= osd_play_lockout - 20'd1;
+	if (osd_stop_lockout != 20'd0) osd_stop_lockout <= osd_stop_lockout - 20'd1;
+	if (tap_loaded && osd_ff_pulse)   osd_ff_lockout   <= OSD_CMD_LOCKOUT;
+	if (tap_loaded && osd_rew_pulse)  osd_rew_lockout  <= OSD_CMD_LOCKOUT;
+	if (tap_loaded && osd_play_pulse) osd_play_lockout <= OSD_CMD_LOCKOUT;
+	if (tap_loaded && osd_stop_pulse) osd_stop_lockout <= OSD_CMD_LOCKOUT;
+
+	osd_ff_d   <= osd_ff;
+	key_ff_d   <= key_ff;
+	osd_rew_d  <= osd_rew;
+	key_rew_d  <= key_rew;
+	osd_play_d <= osd_play;
+	key_play_d <= key_play;
+	osd_stop_d <= osd_stop;
+	key_stop_d <= key_stop;
+
+	if (tap_reset) begin
+		// c1530 requires one more byte at the end due to FIFO early check.
+		tap_last_addr_r <= tap_download ? ioctl_addr + 2'd2 : 25'd0;
+		tap_play_addr_r <= 25'd0;
+		tap_start       <= ~tape_autoplay_off & tap_download;
+		read_cyc        <= 1'b0;
+		tape_ff         <= 1'b0;
+		tape_rew        <= 1'b0;
+		tap_map_rdaddr  <= 13'd0;
+		tap_map_update  <= 1'b0;
+		tap_map_update_d <= 1'b0;
+		tape_stop_pulse <= 1'b0;
+		tape_seek_reset <= 1'b0;
+		tape_play_pulse <= 1'b0;
+		osd_ff_d <= osd_ff;
+		osd_rew_d <= osd_rew;
+		osd_play_d <= osd_play;
+		osd_stop_d <= osd_stop;
+		osd_ff_lockout <= 20'd0;
+		osd_rew_lockout <= 20'd0;
+		osd_play_lockout <= 20'd0;
+		osd_stop_lockout <= 20'd0;
+	end else begin
+		tap_start <= 1'b0;
+
+		// At physical end keep the TAP mounted, but release PLAY once so the
+		// Datassette state becomes STOP instead of auto-unloading the image.
+		if (tap_at_end && ~cass_sense) begin
+			tape_ff <= 1'b0;
+			tape_rew <= 1'b0;
+			tape_stop_pulse <= 1'b1;
+		end
+
+		// FF/REW commands select a transport direction. OSD events are treated as
+		// start commands so a possible OSD set/clear pair cannot cancel itself.
+		// Keyboard shortcuts keep the previous toggle behavior.
+		if (tap_loaded && ff_edge) begin
+			tape_ff  <= osd_ff_pulse ? 1'b1 : ~tape_ff;
+			tape_rew <= 1'b0;
+			if (~cass_sense) tape_stop_pulse <= 1'b1;
+		end
+
+		if (tap_loaded && rew_edge) begin
+			tape_rew <= osd_rew_pulse ? 1'b1 : ~tape_rew;
+			tape_ff  <= 1'b0;
+			if (~cass_sense) tape_stop_pulse <= 1'b1;
+		end
+
+		// PLAY stops winding.
+		if (tap_loaded && play_edge) begin
+			tape_ff  <= 1'b0;
+			tape_rew <= 1'b0;
+			tape_play_pulse <= 1'b1;
+		end
+
+		// STOP stops winding and forces C1530 to STOP if PLAY is pressed.
+		if (tap_loaded && stop_edge) begin
+			tape_ff  <= 1'b0;
+			tape_rew <= 1'b0;
+			if (~cass_sense) tape_stop_pulse <= 1'b1;
+		end
+
+		// Auto-stop at tape bounds.
+		if (tape_ff  && (tc_abs_count + 1'b1 >= tap_map_max)) tape_ff  <= 1'b0;
+		if (tape_rew && tc_at_start) tape_rew <= 1'b0;
+
+		if (tape_winding) begin
+			read_cyc <= 1'b0;
+			if (tc_wind_step) begin
+				if (tape_ff && (tc_abs_count + 1'b1 < tap_map_max)) begin
+					tap_map_rdaddr <= tc_abs_count + 1'b1;
+					tap_map_update <= 1'b1;
+				end else if (tape_rew && !tc_at_start) begin
+					tap_map_rdaddr <= tc_abs_count - 1'b1;
+					tap_map_update <= 1'b1;
+				end
+			end
+		end else begin
+			// Normal playback.  c64.sv already points the SDRAM TAP prefetch at
+			// tap_play_addr_r; sdram_data is valid on the matching later phase.
+			if (~io_cycle & io_cycleD & ~tap_wrfull & tap_loaded & ~tap_at_end) read_cyc <= 1'b1;
+			if (io_cycle & io_cycleD & read_cyc) begin
+				tap_play_addr_r <= tap_play_addr_r + 1'b1;
+				read_cyc <= 1'b0;
+				tap_wrreq[0] <= 1'b1;
+			end
+		end
+
+		// BRAM read latency compensation. c1530 always skips the 20-byte TAP
+		// header after a restart, and the SDRAM prefetch has already queued the
+		// next byte when the seek reset is asserted. Seek the feeder 21 bytes before
+		// the mapped token so playback resumes at the requested safe offset.
+		if (tap_map_update_d) begin
+			tap_play_addr_r <= (tap_map_rddata > 25'd21) ? (tap_map_rddata - 25'd21) : 25'd0;
+			tape_seek_reset <= 1'b1;
+		end
+	end
+end
+
+c1530 c1530
+(
+	.clk32(clk),
+	.restart_tape(tap_reset | tape_seek_reset),
+	.wav_mode(1'b0),
+	.tap_version(tap_version),
+	.host_tap_in(sdram_data),
+	.host_tap_wrreq(tap_wrreq[1]),
+	.tap_fifo_wrfull(tap_wrfull),
+	.tap_fifo_error(cass_finish),
+	.cass_read(cass_read),
+	.cass_write(cass_write),
+	.cass_motor(cass_motor),
+	.cass_sense(cass_sense),
+	.cass_run(cass_run),
+	.osd_play_stop_toggle(tape_play_pulse | tap_start | tape_stop_pulse),
+	.ear_input(1'b0)
+);
+
+endmodule


### PR DESCRIPTION
Added many new features to C1530, like Rewind, Fast Forward, Counter overlay, reset counter only, keyboard shortcuts for C1530. Play, Rewind and Fast Forward are accurate to real Datassette, CUTE32 and also VICE emulator.

Co-authored-by: Roberto Lari <lroby74@gmail.com>